### PR TITLE
Refactor nxsunit

### DIFF
--- a/sasdata/data_util/nxsunit.py
+++ b/sasdata/data_util/nxsunit.py
@@ -43,25 +43,30 @@ allow the application to set the dimension for the unit rather than
 inferring the dimension from an example unit.
 """
 
-# TODO: Add udunits to NAPI rather than reimplementing it in python
-# TODO: Alternatively, parse the udunits database directly
-# UDUnits:
-#  http://www.unidata.ucar.edu/software/udunits/udunits-1/udunits.txt
-
+from __future__ import division
 import math
+import re
+
 
 __all__ = ['Converter']
+DIMENSIONS = {}  # type: Dict[str, Dict[str, ConversionType]]
+AMBIGUITIES = {}  # type: Dict[str, str]
+PREFIX = dict(peta=1e15, tera=1e12, giga=1e9, mega=1e6, kilo=1e3, deci=1e-1, centi=1e-2, milli=1e-3, mili=1e-3,
+              micro=1e-6, nano=1e-9, pico=1e-12, femto=1e-15)
+SHORT_PREFIX = dict(P=1e15, T=1e12, G=1e9, M=1e6, k=1e3, d=1e-1, c=1e-2, m=1e-3, u=1e-6, n=1e-9, p=1e-12, f=1e-15)
+
 
 # Limited form of units for returning objects of a specific type.
 # Maybe want to do full units handling with e.g., pyre's
 # unit class. For now lets keep it simple.  Note that
-def _build_metric_units(unit,abbr):
+def _build_metric_units(unit, abbr):
+    # type: (str, str) -> dict[str, float]
     """
     Construct standard SI names for the given unit.
     Builds e.g.,
-        s, ns
-        second, nanosecond, nano*second
-        seconds, nanoseconds
+        s, ns, n*s, n_s
+        second, nanosecond, nano*second, nano_second
+        seconds, nanoseconds, nano*seconds, nano_seconds
     Includes prefixes for femto through peta.
 
     Ack! Allows, e.g., Coulomb and coulomb even though Coulomb is not
@@ -69,147 +74,379 @@ def _build_metric_units(unit,abbr):
 
     Returns a dictionary of names and scales.
     """
-    prefix = dict(peta=1e15,tera=1e12,giga=1e9,mega=1e6,kilo=1e3,
-                  deci=1e-1,centi=1e-2,milli=1e-3,mili=1e-3,micro=1e-6,
-                  nano=1e-9,pico=1e-12,femto=1e-15)
-    short_prefix = dict(P=1e15,T=1e12,G=1e9,M=1e6,k=1e3,
-                        d=1e-1,c=1e-2,m=1e-3,u=1e-6,
-                        n=1e-9,p=1e-12,f=1e-15)
-    map = {abbr:1}
-    map.update([(P+abbr,scale) for (P,scale) in short_prefix.items()])
-    for name in [unit,unit.capitalize()]:
-        map.update({name:1,name+'s':1})
-        map.update([(P+name,scale) for (P,scale) in prefix.items()])
-        map.update([(P+'*'+name,scale) for (P,scale) in prefix.items()])
-        map.update([(P+name+'s',scale) for (P,scale) in prefix.items()])
+    map = {}
+    for name in [unit, unit.capitalize(), unit.lower(), abbr]:
+        for items in [PREFIX, SHORT_PREFIX]:
+            names = {}
+            names.update({name: 1})
+            names.update([(P + name, scale) for (P, scale) in items.items()])
+            names.update([(P + '*' + name, scale) for (P, scale) in items.items()])
+            names.update([(P + '_' + name, scale) for (P, scale) in items.items()])
+            # Exclude pluralized abbrevs., e.g. create m(illi)(?)(*|_)(?)meters, but not milli(*|_)(?)ms or m(*|_)(?)ms
+            if name != abbr:
+                names.update(_build_plural_units(**names))
+            map.update(names)
     return map
 
+
 def _build_plural_units(**kw):
+    # type: (dict[str, float]) -> dict[str, float]
     """
     Construct names for the given units.  Builds singular and plural form.
     """
     map = {}
-    map.update([(name,scale) for name,scale in kw.items()])
-    map.update([(name+'s',scale) for name,scale in kw.items()])
+    map.update([(name, scale) for name, scale in kw.items()])
+    map.update([(name + 's', scale) for name, scale in kw.items()])
     return map
 
-def _caret_optional(s):
-    """
-    Strip '^' from unit names.
 
-    * WARNING * this will incorrectly transform 10^3 to 103.
+def _build_degree_units(name, symbol, conversion):
+    # type: (str, str, ConversionType) -> Dict[str, ConversionType]
     """
-    stripped = [(k.replace('^',''),v) for k, v in s.items() if '^' in k]
-    s.update(stripped)
+    Builds variations on the temperature unit name, including the degree
+    symbol or the word degree.
+    """
+    map = {}  # type: Dict[str, ConversionType]
+    map[symbol] = conversion
+    for s in symbol, symbol.lower():
+        map['deg' + s] = conversion
+        map['deg_' + s] = conversion
+        map['°' + s] = conversion
+    for s in name, name.capitalize(), symbol, symbol.lower():
+        map[s] = conversion
+        map['degree_' + s] = conversion
+        map['degree' + s] = conversion
+        map['degrees' + s] = conversion
+    return map
+
+
+def _build_inv_n_units(names, conversion, n=2):
+    # type: (Sequence[str], ConversionType, int) -> Dict[str, ConversionType]
+    """
+    Builds variations on inverse x to the nth power units, including 1/x^n, invx^n, x^-n and x^{-n}.
+    """
+    map = {}  # type: Dict[str, ConversionType]
+    n = int(n)
+    for s in names:
+        map[f'1/{s}^{n}'] = conversion
+        map[f'inv{s}^{n}'] = conversion
+        map[f'{s}^-{n}'] = conversion
+        map[s + '^{-' + str(n) + '}'] = conversion
+    return map
+
+
+def _build_inv_n_metric_units(unit, abbr, n=2):
+    # type: (Sequence[str], ConversionType, int) -> Dict[str, ConversionType]
+    """
+    Using the return from _build_metric_units, build inverse to the nth power variations on all units
+    (1/x^n, invx^n, x^{-n} and x^-n)
+    """
+    map = {}  # type: Dict[str, ConversionType]
+    meter_map = _build_metric_units(unit, abbr)
+    n = int(n)
+    for s, c in meter_map.items():
+        conversion = 1/(math.pow(float(c), n))
+        map.update(_build_inv_n_units([s], conversion, n))
+    return map
+
 
 def _build_all_units():
-    distance = _build_metric_units('meter','m')
-    distance.update(_build_metric_units('metre','m'))
+    # type: () -> None
+    """
+    Fill in the global variables DIMENSIONS and AMBIGUITIES for all available
+    dimensions.
+    """
+    # Gather all the ambiguities in one spot
+    AMBIGUITIES['A'] = 'distance'  # distance, current
+    AMBIGUITIES['second'] = 'time'  # time, angle
+    AMBIGUITIES['seconds'] = 'time'
+    AMBIGUITIES['sec'] = 'time'
+    AMBIGUITIES['°'] = 'angle'  # temperature, angle
+    AMBIGUITIES['minute'] = 'angle'  # time, angle
+    AMBIGUITIES['minutes'] = 'angle'
+    AMBIGUITIES['min'] = 'angle'
+    AMBIGUITIES['C'] = 'charge'  # temperature, charge
+    AMBIGUITIES['F'] = 'temperature'  # temperature
+    AMBIGUITIES['R'] = 'radiation'  # temperature:rankines, radiation:roentgens
+
+    # Distance measurements
+    distance = _build_metric_units('meter', 'm')
+    distance.update(_build_metric_units('metre', 'm'))
     distance.update(_build_plural_units(micron=1e-6, Angstrom=1e-10))
-    distance.update({'A':1e-10, 'Ang':1e-10})
+    distance.update({'Å': 1e-10, 'A': 1e-10, 'Ang': 1e-10,  'ang': 1e-10})
+    DIMENSIONS['distance'] = distance
 
-    # Note: minutes are used for angle
-    time = _build_metric_units('second','s')
-    time.update(_build_plural_units(hour=3600,day=24*3600,week=7*24*3600))
+    # Time measurements
+    time = _build_metric_units('second', 's')
+    time.update(_build_plural_units(minute=60, hour=3600, day=24 * 3600, week=7 * 24 * 3600))
+    time.update({'sec': 1., 'min': 60., 'hr': 3600.})
+    time.update({'1e-7 s': 1e-7, '1e-7 second': 1e-7, '1e-7 seconds': 1e-7})
+    DIMENSIONS['time'] = time
 
-    # Note: seconds are used for time
-    angle = _build_plural_units(degree=1, minute=1/60.,
-                  arcminute=1/60., arcsecond=1/3600., radian=180/math.pi)
-    angle.update(deg=1, arcmin=1/60., arcsec=1/3600., rad=180/math.pi)
+    # Various angle measures.
+    angle = _build_plural_units(
+        degree=1., minute=1 / 60., second=1 / 3600.,
+        arcdegree=1., arcminute=1 / 60., arcsecond=1 / 3600.,
+        radian=180 / math.pi)
+    # Note: shouldn't need the extra dict() in the line below, but mypy is
+    # confused if we don't.
+    angle.update(dict(
+        deg=1., min=1 / 60., sec=1 / 3600.,
+        arcdeg=1., arcmin=1 / 60., arcsec=1 / 3600.,
+        angular_degree=1., angular_minute=1 / 60., angular_second=1 / 3600.,
+        rad=180. / math.pi,
+    ))
+    angle['°'] = 1.
+    DIMENSIONS['angle'] = angle
 
-    frequency = _build_metric_units('hertz','Hz')
-    frequency.update(_build_metric_units('Hertz','Hz'))
-    frequency.update(_build_plural_units(rpm=1/60.))
+    frequency = _build_metric_units('hertz', 'Hz')
+    frequency.update(_build_metric_units('Hertz', 'Hz'))
+    frequency.update(_build_plural_units(rpm=1 / 60.))
+    frequency.update(_build_inv_n_metric_units('second', 's', 1))
+    DIMENSIONS['frequency'] = frequency
 
     # Note: degrees are used for angle
-    # Note: temperature needs an offset as well as a scale
-    temperature = _build_metric_units('kelvin','K')
-    temperature.update(_build_metric_units('Kelvin','K'))
-    temperature.update(_build_metric_units('Celcius', 'C'))
-    temperature.update(_build_metric_units('celcius', 'C'))
+    temperature = _build_metric_units('kelvin', 'K')
+    for k, v in temperature.items():
+        # add offset 0 to all kelvin temperatures
+        temperature[k] = (v, 0.)  # type: ignore
+    temperature.update(_build_degree_units('celcius', 'C', (1., 273.15)))
+    temperature.update(_build_degree_units('centigrade', 'C', temperature['degC']))
+    temperature.update(_build_degree_units('fahrenheit', 'F', (5. / 9., 491.67 - 32)))
+    temperature.update(_build_degree_units('rankine', 'R', (5. / 9., 0)))
+    # special unicode symbols for fahrenheit and celcius
+    temperature['℃'] = temperature['degC']
+    temperature['℉'] = temperature['degF']
+    DIMENSIONS['temperature'] = temperature
 
-    charge = _build_metric_units('coulomb','C')
-    charge.update({'microAmp*hour':0.0036})
+    # Charge
+    charge = _build_metric_units('coulomb', 'C')
+    charge['microAmp*hour'] = 0.0036
+    DIMENSIONS['charge'] = charge
 
-    sld = { '10^-6 Angstrom^-2': 1e-6, 'Angstrom^-2': 1 }
-    Q = { 'invA': 1, 'invAng': 1, 'invAngstroms': 1, '1/A': 1,
-          '1/Angstrom': 1, '1/angstrom': 1, 'A^{-1}': 1, 'cm^{-1}': 1e-8,
-          '10^-3 Angstrom^-1': 1e-3, '1/cm': 1e-8, '1/m': 1e-10,
-          'nm^{-1}': 1, 'nm^-1': 0.1, '1/nm': 0.1, 'n_m^-1': 0.1 }
+    # Resistance Units
+    resistance = _build_metric_units('ohm', 'Ω')
+    DIMENSIONS['resistance'] = resistance
 
-    _caret_optional(sld)
-    _caret_optional(Q)
+    # Scattering length densities and inverse area units
+    sld = _build_inv_n_metric_units('meter', 'm', 2)
+    sld.update(_build_inv_n_units(('Å', 'A', 'Ang', 'Angstrom', 'ang', 'angstrom'), 1.0e10, 2))
+    sld['10^-6 Angstrom^-2'] = 1e-6
+    DIMENSIONS['sld'] = sld
 
-    dims = [distance, time, angle, frequency, temperature, charge, sld, Q]
-    return dims
+    # Q units (also inverse lengths)
+    Q = _build_inv_n_metric_units('meter', 'm', 1)
+    Q.update(_build_inv_n_units(('Å', 'A', 'Ang', 'Angstrom', 'ang', 'angstrom'), 1.0e10, 1))
+    Q['10^-3 Angstrom^-1'] = 1e-3
+    DIMENSIONS['Q'] = Q
+
+    # Inverse volume units
+    scattering_volume = _build_inv_n_metric_units('meter', 'm', 3)
+    scattering_volume.update(_build_inv_n_units(('Å', 'A', 'Ang', 'Angstrom', 'ang', 'angstrom'), 1.0e10, 3))
+    DIMENSIONS['scattering_volume'] = scattering_volume
+
+    # TODO: break into separate dimension blocks to allow scaling of complex units
+    #  SANS units => ['A^{-2}']
+    #  SESANS units => ['A^{-2}', 'cm^{-1}']
+    #  Will require more complexity to scale calculations
+    DIMENSIONS['SESANS'] = {'Å^{-2} cm^{-1}': 1, 'A^{-2} cm^{-1}': 1}
+
+    # Energy units
+    energy = _build_metric_units('electronvolt', 'eV')
+    DIMENSIONS['energy'] = energy
+    # Note: energy <=> wavelength <=> velocity requires a probe type
+
+    # Magnetic moment units
+    magnetism = _build_metric_units('tesla', 'T')
+    gauss = _build_metric_units('gauss', 'G')
+    gauss = dict((k, v * 1e-4) for k, v in gauss.items())
+    magnetism.update(gauss)
+    DIMENSIONS['magnetism'] = magnetism
+
+    # APS files may be using 'a.u.' for 'arbitrary units'.  Other
+    # facilities are leaving the units blank, using ??? or not even
+    # writing the units attributes.
+    unknown = {}  # type: Dict[str, ConversionType]
+    unknown.update(
+        {'None': 1, '???': 1, '': 1, 'A.U.': 1,  'a.u.': 1, 'arbitrary': 1, 'arbitrary units': 1,
+         'Counts': 1, 'counts': 1, 'Cts': 1, 'cts': 1, 'unitless': 1, 'unknown': 1, 'Unknown': 1, 'Unk': 1}
+    )
+    DIMENSIONS['dimensionless'] = unknown
+
+
+def standardize_units(unit):
+    # type: (str) -> str
+    """
+    Convert supplied units to a standard format for maintainability
+    :param unit: Raw unit as supplied
+    :return: Unit with known, reduced values
+    """
+    # Convert value to a string -> Sets None to 'None'
+    # Useful for GUI elements that require string values
+    unit = str(unit)
+    # Catch ang, angstrom, ANG, ANGSTROM, and any capitalization in between
+    # Replace with 'Å'
+    unit = re.sub(r'[ÅAa]ng(str[oö]m)?(s)?', 'Å', unit, flags=re.IGNORECASE)
+    # Catch meter, metre, METER, METRE, and any capitalization in between
+    # Replace with 'm'
+    unit = re.sub(r'(met(er|re)(s)?)', 'm', unit, flags=re.IGNORECASE)
+    # Catch second, sec, SECOND, SEC, and any capitalization in between
+    # Replace with 's'
+    unit = re.sub(r'sec(ond)?(s)?', 's', unit, flags=re.IGNORECASE)
+    # Catch kelvin, KELVIN, and any capitalization in between
+    # Replace with 'K'
+    unit = re.sub(r'kel(vin)?(s)?', 'K', unit, flags=re.IGNORECASE)
+    # Catch celcius, CELCIUS, and any capitalization in between
+    # Replace with '℃'
+    unit = re.sub(r'cel(cius)?', '℃', unit)
+    # Catch hertz, HERTZ, hz, HZ, and any capitalization in between
+    # Replace with 'Hz'
+    unit = re.sub(r'h(ert)?z', 'Hz', unit)
+    # Catch arbitrary units, arbitrary, and any capitalization
+    # Replace with 'a.u.'
+    unit = re.sub(r'(arb(itrary|[.]|)?( )?(units)?|a[.] ?u[.]|au[.]?|aus[.]?)',
+                  'a.u.', unit, flags=re.IGNORECASE)
+    unit = re.sub(r'(unk)(nown)?', 'Unk', unit, flags=re.IGNORECASE)
+    unit = re.sub(r'(c)(oun)?(t)(s)?', 'cts', unit, flags=re.IGNORECASE)
+    return _format_unit_structure(unit)
+
+
+def _format_unit_structure(unit=None):
+    """
+    Format units a common way
+    :param unit: Unit string to be formatted
+    :return: Formatted unit string
+    """
+    # Convert value to a string -> Sets None to 'None'
+    # Useful for GUI elements that require string values
+    unit = str(unit)
+    # a-m[ /?]b-n ... -> a^m b^-n
+    unit = re.sub('([℃ÅA-Za-z_ ]+)([-0-9]+)', r"\1^\2", unit)
+    # centi*metre -> centimetre (before converting * -> ' ')
+    all_prefixes = list(PREFIX.keys())
+    all_prefixes.extend(list(SHORT_PREFIX.keys()))
+    for prefix in all_prefixes:
+        unit = unit.replace(prefix + "*", prefix)
+    # a^-m*b^-n -> a^-m b^-n
+    unit = unit.replace('*', ' ')
+    # invUnit or 1/unit -> /unit
+    for x in ['inv', '1/']:
+        unit = re.sub(x, '/', unit, flags=re.IGNORECASE)
+    # (a_m^2 b_n^-3) -> am^2 bn^-3
+    for x in ['_', '(', ')']:
+        unit = unit.replace(x, '')
+    final = ''
+    factors = unit.split('/')
+    # am^2/bn^2 c -> am^{{2}} bn^{{-2}} c^{{-1}}
+    for i in range(len(factors)):
+        sign = '-' if i > 0 else ''
+        for item in factors[i].split():
+            if item == '':
+                continue
+            ct_split = item.split('^')
+            final += f"{ct_split[0]}"
+            number = 1 if len(ct_split) == 1 else ct_split[1]
+            final += (f"^{{{sign}{number}}} "
+                      if len(ct_split) > 1 or sign == '-'
+                      else " ")
+    # ' am^{{2}} bn^{{-2}} c^{{-1}} ' -> 'am^{2} bn^{-2} c^{-1}'
+    return final.strip().replace('{{', '{').replace('}}', '}')
+
+
+# Initialize DIMENSIONS and AMBIGUITIES
+_build_all_units()
+
 
 class Converter(object):
     """
     Unit converter for NeXus style units.
+
+    The converter is initialized with the units of the source value.  Various
+    source values can then be converted to target values based on target
+    value name.
     """
-    # Define the units, using both American and European spelling.
-    scalemap = None
-    scalebase = 1
-    dims = _build_all_units()
+    #: Name of the source units (km, Ang, us, ...)
+    units = None  # type: str
+    #: Type of the source units (distance, time, frequency, ...)
+    dimension = None  # type: str
+    #: Scale converter, mapping unit name to scale factor or (scale, offset)
+    #: for temperature units.
+    scalemap = None  # type: Dict[str, ConversionType]
+    #: Scale base for the source units
+    scalebase = None  # type: ConversionType
 
-    # Note: a.u. stands for arbitrary units, which should return the default
-    # units for that particular dimension.
-    # Note: don't have support for dimensionless units.
-    unknown = {None: 1, '???': 1, '': 1, 'a.u.': 1, 'Counts': 1, 'counts': 1,
-               'arbitrary': 1, 'arbitrary units': 1}
+    def __init__(self, units=None, dimension=None):
+        # type: (Optional[str], Optional[str]) -> self
+        self.units = standardize_units(units) if units is not None else ''  # type: str
 
-    def __init__(self, name):
-        self.base = name
-        for map in self.dims:
-            if name in map:
-                self.scalemap = map
-                self.scalebase = self.scalemap[name]
-                return
-        if name in self.unknown:
-            return # default scalemap and scalebase correspond to unknown
+        # Lookup dimension if not given
+        if dimension:
+            self.dimension = dimension
+        elif self.units in AMBIGUITIES:
+            self.dimension = AMBIGUITIES[self.units]
         else:
-            raise KeyError("Unknown unit %s"%name)
+            for k, v in DIMENSIONS.items():
+                if self.units in v:
+                    self.dimension = k
+                    break
+            else:
+                self.dimension = 'dimensionless'
 
-    def scale(self, units=""):
-        if units == "" or self.scalemap is None: return 1
-        return self.scalebase/self.scalemap[units]
+        # Find the scale for the given units - default to dimensionless
+        self.scalemap = DIMENSIONS.get(self.dimension, DIMENSIONS['dimensionless'])
+        self.scalebase = self.scalemap.get(self.units) if self.scalemap else 1.0
+
+    def scale(self, units="", value=None):
+        # type: (str, T) -> T
+        """Scale the given value using the units string supplied"""
+        units = standardize_units(units) if units is not None else ''
+        if units and units not in self.scalemap or value is None:
+            return value
+        if isinstance(value, list):
+            return [self.scale(units, i) for i in value]
+        return value * self.scalebase / self.scalemap[units]
+
+    def scale_with_offset(self, units="", value=None):
+        # type: (str, T) -> T
+        """Scale the given value and add the offset using the units string supplied"""
+        units = standardize_units(units) if units is not None else ''
+        if units and units not in self.scalemap or value is None:
+            return value
+        if isinstance(value, list):
+            return [self.scale_with_offset(units, i) for i in value]
+        inscale, inoffset = self.scalebase
+        outscale, outoffset = self.scalemap[units]
+        return (value + inoffset) * inscale / outscale - outoffset
+
+    def get_compatible_units(self):
+        # type: () -> [str]
+        """Return a list of compatible units for the current Convertor object"""
+        unique_units = []
+        conv_list = []
+        for item, conv in self.scalemap.items():
+            unit = standardize_units(item)
+            if unit not in unique_units and unit is not None:
+                unique_units.append(unit)
+                conv_list.append(conv)
+        unique_units = [x for _, x in sorted(zip(conv_list, unique_units))]
+        return unique_units
 
     def __call__(self, value, units=""):
+        # type: (T, str) -> T
         # Note: calculating a*1 rather than simply returning a would produce
         # an unnecessary copy of the array, which in the case of the raw
         # counts array would be bad.  Sometimes copying and other times
         # not copying is also bad, but copy on modify semantics isn't
         # supported.
-        if units == "" or self.scalemap is None: return value
+        if not units:
+            return value
         try:
-            return value * (self.scalebase/self.scalemap[units])
+            return self.scale(units, value)  # type: ignore
         except KeyError:
-            possible_units = ", ".join(str(k) for k in self.scalemap.keys())
-            raise KeyError("%s not in %s"%(units,possible_units))
-
-def _check(expect,get):
-    if expect != get:
-        raise ValueError("Expected %s but got %s"%(expect, get))
-     #print expect,"==",get
-
-def test():
-    _check(1,Converter('n_m^-1')(10,'invA')) # 10 nm^-1 = 1 inv Angstroms
-    _check(2,Converter('mm')(2000,'m')) # 2000 mm -> 2 m
-    _check(2.011e10,Converter('1/A')(2.011,"1/m")) # 2.011 1/A -> 2.011 * 10^10 1/m
-    _check(0.003,Converter('microseconds')(3,units='ms')) # 3 us -> 0.003 ms
-    _check(45,Converter('nanokelvin')(45))  # 45 nK -> 45 nK
-    _check(0.5,Converter('seconds')(1800,units='hours')) # 1800 s -> 0.5 hr
-    _check(123,Converter('a.u.')(123,units='mm')) # arbitrary units always returns the same value
-    _check(123,Converter('a.u.')(123,units='s')) # arbitrary units always returns the same value
-    _check(123,Converter('a.u.')(123,units='')) # arbitrary units always returns the same value
-    try:
-        Converter('help')
-    except KeyError:
-        pass
-    else:
-        raise Exception("unknown unit did not raise an error")
-
-    # TODO: more tests
-
-if __name__ == "__main__":
-    test()
+            exc = KeyError("%s is not a %s" % (units, self.dimension))
+            exc.__cause__ = None
+            raise exc
+        except TypeError:
+            # For temperatures, a type error is raised because the conversion
+            # factor is (scale, offset) rather than scale.
+            return self.scale_with_offset(units, value)  # type: ignore

--- a/sasdata/data_util/nxsunit.py
+++ b/sasdata/data_util/nxsunit.py
@@ -288,10 +288,10 @@ def standardize_units(unit: Union[str, None]) -> List[str]:
     unit = re.sub(r'kel(vin)?(s)?', 'K', unit, flags=re.IGNORECASE)
     # Catch celcius, CELCIUS, and any capitalization in between
     # Replace with '℃'
-    unit = re.sub(r'cel(cius)?', '℃', unit)
+    unit = re.sub(r'cel(cius)?', '℃', unit, flags=re.IGNORECASE)
     # Catch hertz, HERTZ, hz, HZ, and any capitalization in between
     # Replace with 'Hz'
-    unit = re.sub(r'h(ert)?z', 'Hz', unit)
+    unit = re.sub(r'h(ert)?z', 'Hz', unit, flags=re.IGNORECASE)
     # Catch arbitrary units, arbitrary, and any capitalization
     # Replace with 'a.u.'
     unit = re.sub(r'(arb(itrary|[.]|)?( )?(units)?|a[.] ?u[.]|au[.]?|aus[.]?)',

--- a/test/sasdataloader/utest_abs_reader.py
+++ b/test/sasdataloader/utest_abs_reader.py
@@ -32,33 +32,33 @@ class abs_reader(unittest.TestCase):
         self.assertEqual(self.data.meta_data['loader'], "IGOR 1D")
 
         self.assertEqual(self.data.source.wavelength_unit, 'A')
-        self.assertEqual(self.data.source.wavelength, 6.0)
+        self.assertAlmostEqual(self.data.source.wavelength, 6.0)
 
         self.assertEqual(self.data.detector[0].distance_unit, 'mm')
-        self.assertEqual(self.data.detector[0].distance, 1000.0)
+        self.assertAlmostEqual(self.data.detector[0].distance, 1000.0)
 
-        self.assertEqual(self.data.sample.transmission, 0.5667)
+        self.assertAlmostEqual(self.data.sample.transmission, 0.5667)
 
         self.assertEqual(self.data.detector[0].beam_center_unit, 'mm')
         center_x = 114.58*5.08
         center_y = 64.22*5.08
-        self.assertEqual(self.data.detector[0].beam_center.x, center_x)
-        self.assertEqual(self.data.detector[0].beam_center.y, center_y)
+        self.assertAlmostEqual(self.data.detector[0].beam_center.x, center_x)
+        self.assertAlmostEqual(self.data.detector[0].beam_center.y, center_y)
 
         self.assertEqual(self.data.y_unit, 'cm^{-1}')
-        self.assertEqual(self.data.x[0], 0.008082)
-        self.assertEqual(self.data.x[1], 0.0275)
-        self.assertEqual(self.data.x[2], 0.02762)
-        self.assertEqual(self.data.x[126], 0.5828)
+        self.assertAlmostEqual(self.data.x[0], 0.008082)
+        self.assertAlmostEqual(self.data.x[1], 0.0275)
+        self.assertAlmostEqual(self.data.x[2], 0.02762)
+        self.assertAlmostEqual(self.data.x[126], 0.5828)
 
-        self.assertEqual(self.data.y[0], 0.02198)
-        self.assertEqual(self.data.y[1], 0.02201)
-        self.assertEqual(self.data.y[2], 0.02695)
-        self.assertEqual(self.data.y[126], 0.2958)
+        self.assertAlmostEqual(self.data.y[0], 0.02198)
+        self.assertAlmostEqual(self.data.y[1], 0.02201)
+        self.assertAlmostEqual(self.data.y[2], 0.02695)
+        self.assertAlmostEqual(self.data.y[126], 0.2958)
 
-        self.assertEqual(self.data.dy[0], 0.002704)
-        self.assertEqual(self.data.dy[1], 0.001643)
-        self.assertEqual(self.data.dy[2], 0.002452)
+        self.assertAlmostEqual(self.data.dy[0], 0.002704)
+        self.assertAlmostEqual(self.data.dy[1], 0.001643)
+        self.assertAlmostEqual(self.data.dy[2], 0.002452)
         self.assertEqual(self.data.dy[126], 1)
 
     def test_checkdata2(self):
@@ -73,9 +73,9 @@ class abs_reader(unittest.TestCase):
         data_abs = Loader().load(find("sam14_cor.ABS"))[0]
         data_cor = Loader().load(find("sam14_cor.txt"))[0]
         for i in range(0, len(data_abs.x) - 1):
-            self.assertEqual(data_abs.x[i], data_cor.x[i])
-            self.assertEqual(data_abs.y[i], data_cor.y[i])
-            self.assertEqual(data_abs.dxl[i], -data_cor.dx[i])
+            self.assertAlmostEqual(data_abs.x[i], data_cor.x[i])
+            self.assertAlmostEqual(data_abs.y[i], data_cor.y[i])
+            self.assertAlmostEqual(data_abs.dxl[i], -data_cor.dx[i])
             self.assertTrue(data_abs.dxl[i] > 0)
 
 
@@ -99,7 +99,7 @@ class DanseReaderTests(unittest.TestCase):
         self.assertEqual(self.data.meta_data['loader'], "DANSE")
 
         self.assertEqual(self.data.source.wavelength_unit, 'A')
-        self.assertEqual(self.data.source.wavelength, 7.5)
+        self.assertAlmostEqual(self.data.source.wavelength, 7.5)
 
         self.assertEqual(self.data.detector[0].distance_unit, 'mm')
         self.assertAlmostEqual(self.data.detector[0].distance, 5414.99, 3)
@@ -107,17 +107,17 @@ class DanseReaderTests(unittest.TestCase):
         self.assertEqual(self.data.detector[0].beam_center_unit, 'mm')
         center_x = 68.74*5.0
         center_y = 64.77*5.0
-        self.assertEqual(self.data.detector[0].beam_center.x, center_x)
-        self.assertEqual(self.data.detector[0].beam_center.y, center_y)
+        self.assertAlmostEqual(self.data.detector[0].beam_center.x, center_x)
+        self.assertAlmostEqual(self.data.detector[0].beam_center.y, center_y)
 
         self.assertEqual(self.data.I_unit, 'cm^{-1}')
-        self.assertEqual(self.data.data[0], 1.57831)
-        self.assertEqual(self.data.data[1], 2.70983)
-        self.assertEqual(self.data.data[2], 3.83422)
+        self.assertAlmostEqual(self.data.data[0], 1.57831)
+        self.assertAlmostEqual(self.data.data[1], 2.70983)
+        self.assertAlmostEqual(self.data.data[2], 3.83422)
 
-        self.assertEqual(self.data.err_data[0], 1.37607)
-        self.assertEqual(self.data.err_data[1], 1.77569)
-        self.assertEqual(self.data.err_data[2], 2.06313)
+        self.assertAlmostEqual(self.data.err_data[0], 1.37607)
+        self.assertAlmostEqual(self.data.err_data[1], 1.77569)
+        self.assertAlmostEqual(self.data.err_data[2], 2.06313)
 
     def test_generic_loader(self):
         # the generic loader should work as well

--- a/test/sasdataloader/utest_cansas.py
+++ b/test/sasdataloader/utest_cansas.py
@@ -2,7 +2,7 @@
     Unit tests for the new recursive cansas reader
 """
 import os
-import sys
+import math
 import unittest
 import logging
 import warnings
@@ -339,8 +339,8 @@ class cansas_reader_xml(unittest.TestCase):
             self.assertEqual(item.size_unit,'mm')
             self.assertEqual(item.distance_unit,'mm')
 
-            if item.size.x == 50 \
-                and item.distance == 11000.0 \
+            if round(item.size.x, 1) == 50.0 \
+                and round(item.distance, 1) == 11000.0 \
                 and item.name == 'source' \
                 and item.type == 'radius':
                 _found1 = True

--- a/test/sasmanipulations/utest_nxsunit.py
+++ b/test/sasmanipulations/utest_nxsunit.py
@@ -14,14 +14,15 @@ class NXSUnitTests(unittest.TestCase):
         self.base_value = 123
 
     def test_initialization(self):
-        self.assertEqual(self.converter.units, '')
+        self.assertEqual(self.converter.units, 'a.u.')
         self.assertEqual(self.converter.scalebase, 1)
-        self.assertTrue(isinstance(self.converter.scalemap, dict))
-        self.assertIn('None', self.converter.scalemap.keys())
+        self.assertTrue(isinstance(self.converter.scalemap, list))
+        self.assertEqual(len(self.converter.scalemap), 1)
+        self.assertIn('None', self.converter.scalemap[0].keys())
         self.assertEqual(self.k_conv.units, 'nanoK')
         self.assertEqual(self.k_conv.scalebase, 1e-9)
         self.assertEqual(self.k_conv.scaleoffset, 0.0)
-        self.assertEqual(len(self.k_conv.scalemap.keys()), 456)
+        self.assertEqual(len(self.k_conv.scalemap[0].keys()), 456)
 
     def testBasicUnits(self):
         # 10 nm^-1 = 1 inv Angstroms

--- a/test/sasmanipulations/utest_nxsunit.py
+++ b/test/sasmanipulations/utest_nxsunit.py
@@ -1,0 +1,99 @@
+"""
+    Unit tests for the unit conversion tool
+"""
+import unittest
+
+from sasdata.data_util.nxsunit import Converter, standardize_units
+
+
+class NXSUnitTests(unittest.TestCase):
+
+    def setUp(self):
+        self.converter = Converter(None)
+        self.k_conv = Converter('nanoKelvins')
+        self.base_value = 123
+
+    def test_initialization(self):
+        self.assertEqual(self.converter.units, '')
+        self.assertEqual(self.converter.scalebase, 1)
+        self.assertTrue(isinstance(self.converter.scalemap, dict))
+        self.assertIn('None', self.converter.scalemap.keys())
+        self.assertEqual(self.k_conv.units, 'nanoK')
+        self.assertEqual(self.k_conv.scalebase, (1e-9, 0.0))
+        self.assertEqual(len(self.k_conv.scalemap.keys()), 456)
+
+    def testBasicUnits(self):
+        # 10 nm^-1 = 1 inv Angstroms
+        self.assertAlmostEqual(1, Converter('n_m^-1')(10, 'invA'))
+        # Test different 1/A representations
+        self.assertAlmostEqual(1, Converter('/A')(1, 'invA'))
+        # 1.65 1/A = 1.65e10 1/m
+        self.assertAlmostEqual(1.65e10, Converter('/A')(1.65, '/m'), 2)
+        # 2000 mm = 2 m
+        self.assertAlmostEqual(2.0, Converter('mm')(2000, 'm'))
+        # 2.011 1/A = 2.011e10 1/m
+        self.assertAlmostEqual(2.011e10, Converter('1/A')(2.011, "1/m"))
+        # 3 us = 0.003 ms
+        self.assertAlmostEqual(0.003, Converter('microseconds')(3, units='ms'))
+        # 45 nK = 45 nK
+        self.assertAlmostEqual(45, self.k_conv(45))
+        # 1 K = 1e9 nK
+        self.assertAlmostEqual(1, self.k_conv(1e9, 'K'))
+        # 1800 s = 0.5 hr
+        self.assertAlmostEqual(0.5, Converter('seconds')(1800, units='hours'))
+
+    def test_known_unknown_units(self):
+        self.assertEqual(self.base_value,
+                         self.converter(self.base_value, units='a.u.'))
+        self.assertEqual(self.base_value,
+                         Converter('arbitrary')(self.base_value, units='a.u.'))
+        self.assertEqual(self.base_value,
+                         Converter('cts')(self.base_value, units='a.u.'))
+        self.assertEqual(self.base_value,
+                         Converter('Counts')(self.base_value, units='a.u.'))
+        self.assertEqual(self.base_value,
+                         Converter('Unknown')(self.base_value, units='a.u.'))
+        self.assertEqual(self.base_value,
+                         Converter('a.u.')(self.base_value, units='a.u.'))
+        self.assertEqual(self.base_value,
+                         Converter('A.U.')(self.base_value, units='a.u.'))
+        self.assertEqual(self.base_value,
+                         Converter('arbitrary units')(self.base_value, units='a.u.'))
+        self.assertEqual(1, self.converter.scalebase)
+
+    def test_se_units(self):
+        self.assertAlmostEqual(1, Converter('A-2 cm-1')(1, 'Å^{-2} cm^{-1}'))
+        self.assertAlmostEqual(1, Converter('A^-2 cm-1')(1, 'Å^{-2} cm^{-1}'))
+        self.assertAlmostEqual(1, Converter('A-2 cm^-1')(1, 'Å^{-2} cm^{-1}'))
+        self.assertAlmostEqual(1, Converter('A^-2 cm^-1')(1, 'Å^{-2} cm^{-1}'))
+
+    def test_unit_structures(self):
+        # Both should return None
+        self.assertEqual(standardize_units(None), standardize_units('None'))
+        # Test substitutions
+        self.assertEqual('nK', standardize_units('nKelvin'))
+        # Capitalization standardization
+        self.assertEqual(standardize_units('seconds'),
+                         standardize_units('SECONDS'))
+        # Underscore standardization
+        self.assertEqual(standardize_units('n_m'),
+                         standardize_units('nm'))
+        # Different '*' standardizations
+        self.assertEqual(standardize_units('pico*meter'),
+                         standardize_units('picometer'))
+        self.assertEqual(standardize_units('Å^2 Kelvin^4'),
+                         standardize_units('Ang^{2}*K^{4}'))
+        # US vs. European spellings
+        self.assertEqual(standardize_units('meters'),
+                         standardize_units('metres'))
+        # Multiple units
+        self.assertEqual('nanoK^{-4} cm^{-1} Å^{-2}',
+                         standardize_units('nanoKelvin-4 invcm/angstrom^2'))
+        # Numerator vs. Denominator
+        self.assertEqual(standardize_units('A^2/nanoKelvin^4'),
+                         'A^{2} nanoK^{-4}')
+        # Tackle parentheses
+        self.assertEqual(standardize_units('(A^2 B^2)/(C^2)'),
+                         'A^{2} B^{2} C^{-2}')
+        # Multiple divisions
+        self.assertEqual(standardize_units('A/B/C'), 'A B^{-1} C^{-1}')

--- a/test/sasmanipulations/utest_nxsunit.py
+++ b/test/sasmanipulations/utest_nxsunit.py
@@ -72,7 +72,7 @@ class NXSUnitTests(unittest.TestCase):
         # Both should return None
         self.assertEqual(standardize_units(None), standardize_units('None'))
         # Test substitutions
-        self.assertEqual('nK', standardize_units('nKelvin'))
+        self.assertEqual(['nK'], standardize_units('nKelvin'))
         # Capitalization standardization
         self.assertEqual(standardize_units('seconds'),
                          standardize_units('SECONDS'))
@@ -88,13 +88,13 @@ class NXSUnitTests(unittest.TestCase):
         self.assertEqual(standardize_units('meters'),
                          standardize_units('metres'))
         # Multiple units
-        self.assertEqual('nanoK^{-4} cm^{-1} Å^{-2}',
+        self.assertEqual(['nanoK^{-4}', 'cm^{-1}', 'Å^{-2}'],
                          standardize_units('nanoKelvin-4 invcm/angstrom^2'))
         # Numerator vs. Denominator
         self.assertEqual(standardize_units('A^2/nanoKelvin^4'),
-                         'A^{2} nanoK^{-4}')
+                         ['A^{2}', 'nanoK^{-4}'])
         # Tackle parentheses
         self.assertEqual(standardize_units('(A^2 B^2)/(C^2)'),
-                         'A^{2} B^{2} C^{-2}')
+                         ['A^{2}', 'B^{2}', 'C^{-2}'])
         # Multiple divisions
-        self.assertEqual(standardize_units('A/B/C'), 'A B^{-1} C^{-1}')
+        self.assertEqual(standardize_units('A/B/C'), ['A', 'B^{-1}', 'C^{-1}'])

--- a/test/sasmanipulations/utest_nxsunit.py
+++ b/test/sasmanipulations/utest_nxsunit.py
@@ -19,7 +19,8 @@ class NXSUnitTests(unittest.TestCase):
         self.assertTrue(isinstance(self.converter.scalemap, dict))
         self.assertIn('None', self.converter.scalemap.keys())
         self.assertEqual(self.k_conv.units, 'nanoK')
-        self.assertEqual(self.k_conv.scalebase, (1e-9, 0.0))
+        self.assertEqual(self.k_conv.scalebase, 1e-9)
+        self.assertEqual(self.k_conv.scaleoffset, 0.0)
         self.assertEqual(len(self.k_conv.scalemap.keys()), 456)
 
     def testBasicUnits(self):

--- a/test/sasmanipulations/utest_nxsunit.py
+++ b/test/sasmanipulations/utest_nxsunit.py
@@ -11,6 +11,7 @@ class NXSUnitTests(unittest.TestCase):
     def setUp(self):
         self.converter = Converter(None)
         self.k_conv = Converter('nanoKelvins')
+        self.sesans = Converter('A-2 cm-1')
         self.base_value = 123
 
     def test_initialization(self):
@@ -43,6 +44,8 @@ class NXSUnitTests(unittest.TestCase):
         self.assertAlmostEqual(1, self.k_conv(1e9, 'K'))
         # 1800 s = 0.5 hr
         self.assertAlmostEqual(0.5, Converter('seconds')(1800, units='hours'))
+        # 100 nm^-2 = 1 A^-2
+        self.assertAlmostEqual(100, Converter('A^-2')(1.0, 'nm^-2'))
 
     def test_known_unknown_units(self):
         self.assertEqual(self.base_value,
@@ -64,10 +67,32 @@ class NXSUnitTests(unittest.TestCase):
         self.assertEqual(1, self.converter.scalebase)
 
     def test_se_units(self):
-        self.assertAlmostEqual(1, Converter('A-2 cm-1')(1, 'Å^{-2} cm^{-1}'))
-        self.assertAlmostEqual(1, Converter('A^-2 cm-1')(1, 'Å^{-2} cm^{-1}'))
-        self.assertAlmostEqual(1, Converter('A-2 cm^-1')(1, 'Å^{-2} cm^{-1}'))
-        self.assertAlmostEqual(1, Converter('A^-2 cm^-1')(1, 'Å^{-2} cm^{-1}'))
+
+        # Test many variations of the unit structure
+        self.assertAlmostEqual(1, self.sesans(1, 'Å^{-2} cm^{-1}'))
+        # Check units can be scaled independently
+        self.assertAlmostEqual(100, self.sesans(1, 'A-2 m-1'))
+        self.assertAlmostEqual(100, self.sesans(1, 'nm-2 cm-1'))
+        # Check scaling works when modifying multiple units
+        self.assertAlmostEqual(10000, self.sesans(1, 'nm-2 m-1'))
+        # Check forward and backward scaling matches
+        self.assertAlmostEqual(1.0, self.sesans(Converter('nm-2 m-1')(1.0, 'Å^{-2} cm^{-1}'), 'nm-2 m-1'))
+
+    def test_temp_units(self):
+        # Test scaling with offset
+        self.assertAlmostEqual(-273.15, Converter('K')(0, '℃'))
+        self.assertAlmostEqual(273.15, Converter('℃')(0, 'K'))
+        self.assertAlmostEqual(0, Converter('F')(-459.67, 'R'))
+        self.assertAlmostEqual(459.67, Converter('F')(0, 'R'))
+        self.assertAlmostEqual(0, Converter('K')(0, 'R'))
+        # Test forward and backward conversions
+        self.assertAlmostEqual(0, Converter('℃')(Converter('K')(0, '℃'), 'K'))
+        self.assertAlmostEqual(0, Converter('R')(Converter('F')(0, 'R'), 'F'))
+
+    def test_incompatible_units(self):
+        # Ensure incompatible units cannot be scaled
+        self.assertRaises(ValueError, self.k_conv, value=1.0, units='m')
+        self.assertRaises(ValueError, self.converter, value=1.0, units='m')
 
     def test_unit_structures(self):
         # Both should return None


### PR DESCRIPTION
This overhauls the nxsunit module to allow scaling with offsets, and scaling of multi-dimensional and complex units, e.g. SESANS A^-2*cm^-1 will treat the A^-2 and cm^-1 as separate components, each independently scalable. Unit tests were moved from within the module to the global unit test suite.

Fixes #5
Fixes(?) sasview/sasview#2035 - @pkienzle what do you think?