### PR TITLE
Fixing Issue #40 - SectorPhi class throws errors (bin index out of range)

### DIFF
--- a/sasdata/data_util/manipulations.py
+++ b/sasdata/data_util/manipulations.py
@@ -65,18 +65,11 @@ def get_q_compo(dx: float, dy: float, detector_distance: float, wavelength: floa
 
 def flip_phi(phi: float) -> float:
     """
-    Force phi to be within the 0 <= to <= 2pi range by adding or subtracting
-    2pi as necessary
+    Force phi to be within the 0 <= to < 2pi range, using a modulus operation.
 
-    :return: phi in >=0 and <=2Pi
+    :return: phi in range 0 <= phi < 2pi
     """
-    if phi < 0:
-        phi_out = phi + (2 * math.pi)
-    elif phi > (2 * math.pi):
-        phi_out = phi - (2 * math.pi)
-    else:
-        phi_out = phi
-    return phi_out
+    return phi % (2 * np.pi)
 
 
 def get_pixel_fraction_square(x: float, x_min: float, x_max: float) -> float:
@@ -303,13 +296,16 @@ class Binning:
         bin = floor(N * (log(x) - log(min)) / (log(max) - log(min)))
         """
         if self.base:
-            temp_x = self.n_bins * (math.log(value, self.base) - math.log(self.min, self.base))
+            temp_x = math.log(value, self.base) - math.log(self.min, self.base)
             temp_y = math.log(self.max, self.base) - math.log(self.min, self.base)
         else:
-            temp_x = self.n_bins * (value - self.min)
+            temp_x = value - self.min
             temp_y = self.max - self.min
+        # Fixing an issue where certain angular coordinate values give bad bin values
+        if np.fabs(temp_x) > np.fabs(temp_y):
+            temp_x = flip_phi(temp_x)
         # Bin index calulation
-        return int(math.floor(temp_x / temp_y))
+        return int(math.floor(self.n_bins * temp_x / temp_y))
 
 
 ################################################################################


### PR DESCRIPTION
This commit makes the necessary changes to fix the issues with "Wedge Averaging in Phi" using the Wedge Slicer, where certain phi values would cause a 'bin index out of range' error.
The method `Binning.get_bin_index()` from `manipulations.py` now checks if the index it's about to return is bad, and corrects it if so (using an improved version of the flip_phi function).

Fixes #40 

The steps needed to produce the original error have been followed, and the error is now fixed. "Wedge Averaging in Q" was also tested to see if these changes introduce errors in other slicers using the new `get_bin_index()` method, but no problems were found.