### PR TITLE
Finishing the manipulatons.py Rewrite

### DIFF
--- a/sasdata/data_util/new_manipulations.py
+++ b/sasdata/data_util/new_manipulations.py
@@ -1,3 +1,7 @@
+"""
+This module contains various data processors used by Sasview's slicers.
+"""
+
 import numpy as np
 
 from sasdata.dataloader.data_info import Data1D, Data2D
@@ -5,13 +9,23 @@ from sasdata.dataloader.data_info import Data1D, Data2D
 
 def weights_for_interval(array, l_bound, u_bound, interval_type='half-open'):
     """
+    Weight coordinate data by position relative to a specified interval.
+
+    :param array: the array for which the weights are calculated
+    :param l_bound: value defining the lower limit of the region of interest
+    :param u_bound: value defining the upper limit of the region of interest
+    :param interval_type: determines whether the value defined by u_bound is
+                          included within the interval.
+
     If and when fractional binning is implemented (ask Lucas), this function
     will be changed so that instead of outputting zeros and ones, it gives
     fractional values instead. These will depend on how close the array value
     is to being within the interval defined.
     """
-    # These checks could be modified to return fractional bin weights.
-    # The last value in the binning range must be included for to pass utests
+
+    # Whether the endpoint should be included depends on circumstance.
+    # Half-open is used when binning the major axis (except for the final bin)
+    # and closed used for the minor axis and the final bin of the major axis.
     if interval_type == 'half-open':
         in_range = (l_bound <= array) & (array < u_bound)
     elif interval_type == 'closed':
@@ -25,19 +39,43 @@ def weights_for_interval(array, l_bound, u_bound, interval_type='half-open'):
 
 class DirectionalAverage:
     """
-    TODO - write a docstring
+    Average along one coordinate axis of 2D data and return data for a 1D plot.
+    This can also be thought of as a projection onto the major axis: 2D -> 1D.
+
+    This class operates on a decomposed Data2D object, and returns data needed
+    to construct a Data1D object. The class is instantiated with two arrays of
+    orthogonal coordinate data (depending on the coordinate system, these may
+    have undergone some pre-processing) and two corresponding two-element
+    tuples/lists defining the lower and upper limits on the Region of Interest
+    (ROI) for each coordinate axis. One of these axes is averaged along, and
+    the other is divided into bins and becomes the dependent variable of the
+    eventual 1D plot. These are called the minor and major axes respectively.
+    When a class instance is called, it is passed the intensity and error data
+    from the original Data2D object. These should not have undergone any
+    coordinate system dependent pre-processing.
 
     Note that the old version of manipulations.py had an option for logarithmic
     binning which was only used by SectorQ. This functionality is never called
     upon by SasView however, so I haven't implemented it here (yet).
     """
 
-    def __init__(self, major_data, minor_data, major_lims=None,
+    def __init__(self, major_axis=None, minor_axis=None, major_lims=None,
                  minor_lims=None, nbins=100):
         """
+        Set up direction of averaging, limits on the ROI, & the number of bins.
+
+        :param major_axis: Coordinate data for axis onto which the 2D data is
+                           projected.
+        :param minor_axis: Coordinate data for the axis perpendicular to the
+                           major axis.
+        :param major_lims: Lower and upper bounds of the ROI along the major
+                           axis. Given as a 2 element tuple/list.
+        :param minor_lims: Lower and upper bounds of the ROI along the minor
+                           axis. Given as a 2 element tuple/list.
+        :param nbins: The number of bins the major axis is divided up into.
         """
-        if any(not isinstance(data, (list, np.ndarray)) for
-               data in (major_data, minor_data)):
+        if any(not isinstance(coordinate_data, (list, np.ndarray)) for
+               coordinate_data in (major_axis, minor_axis)):
             msg = "Must provide major & minor coordinate arrays for binning."
             raise ValueError(msg)
         if any(lims is not None and len(lims) != 2 for
@@ -48,14 +86,15 @@ class DirectionalAverage:
             msg = "Parameter 'nbins' must be an integer"
             raise TypeError(msg)
 
-        self.major_data = np.asarray(major_data)
-        self.minor_data = np.asarray(minor_data)
+        self.major_axis = np.asarray(major_axis)
+        self.minor_axis = np.asarray(minor_axis)
+        # In some cases all values from a given axis are part of the ROI.
         if major_lims is None:
-            self.major_lims = (self.major_data.min(), self.major_data.max())
+            self.major_lims = (self.major_axis.min(), self.major_axis.max())
         else:
             self.major_lims = major_lims
         if minor_lims is None:
-            self.minor_lims = (self.minor_data.min(), self.minor_data.max())
+            self.minor_lims = (self.minor_axis.min(), self.minor_axis.max())
         else:
             self.minor_lims = minor_lims
         self.nbins = nbins
@@ -63,13 +102,15 @@ class DirectionalAverage:
     @property
     def bin_width(self):
         """
-        Return the bin width
+        Return the bin width based on the range of the major axis and nbins
         """
         return (self.major_lims[1] - self.major_lims[0]) / self.nbins
 
     def get_bin_interval(self, bin_number):
         """
-        Return the upper and lower limits defining a given bin
+        Return the upper and lower limits defining a bin, given its index.
+
+        :param bin_number: The index of the bin (between 0 and self.nbins - 1)
         """
         bin_start = self.major_lims[0] + bin_number * self.bin_width
         bin_end = self.major_lims[0] + (bin_number + 1) * self.bin_width
@@ -78,6 +119,9 @@ class DirectionalAverage:
 
     def get_bin_index(self, value):
         """
+        Return the index of the bin to which the supplied value belongs.
+
+        :param value: A coordinate value from somewhere along the major axis.
         """
         numerator = value - self.major_lims[0]
         denominator = self.major_lims[1] - self.major_lims[0]
@@ -92,22 +136,26 @@ class DirectionalAverage:
 
     def compute_weights(self):
         """
+        Return weights array for the contribution of each datapoint to each bin
+
+        Each row of the weights array corresponds to the bin with the same
+        index.
         """
-        major_weights = np.zeros((self.nbins, self.major_data.size))
+        major_weights = np.zeros((self.nbins, self.major_axis.size))
         for m in range(self.nbins):
             # Include the value at the end of the binning range, but in
-            # general use half-open intervals so each value begins in only
+            # general use half-open intervals so each value belongs in only
             # one bin.
             if m == self.nbins - 1:
                 interval = 'closed'
             else:
                 interval = 'half-open'
             bin_start, bin_end = self.get_bin_interval(bin_number=m)
-            major_weights[m] = weights_for_interval(array=self.major_data,
+            major_weights[m] = weights_for_interval(array=self.major_axis,
                                                     l_bound=bin_start,
                                                     u_bound=bin_end,
                                                     interval_type=interval)
-        minor_weights = weights_for_interval(array=self.minor_data,
+        minor_weights = weights_for_interval(array=self.minor_axis,
                                              l_bound=self.minor_lims[0],
                                              u_bound=self.minor_lims[1],
                                              interval_type='closed')
@@ -115,10 +163,14 @@ class DirectionalAverage:
 
     def __call__(self, data, err_data):
         """
+        Compute the directional average of the supplied intensity & error data.
+
+        :param data: intensity data from the origninal Data2D object.
+        :param err_data: the corresponding errors for the intensity data.
         """
         weights = self.compute_weights()
 
-        x_axis_values = np.sum(weights * self.major_data, axis=1)
+        x_axis_values = np.sum(weights * self.major_axis, axis=1)
         intensity = np.sum(weights * data, axis=1)
         errs_squared = np.sum((weights * err_data)**2, axis=1)
         bin_counts = np.sum(weights, axis=1)
@@ -138,11 +190,16 @@ class DirectionalAverage:
 
 class GenericROI:
     """
-    TODO - add docstring
+    Base class used to set up the data from a Data2D object for processing.
+    This class performs any coordinate system independent setup and validation.
     """
 
     def __init__(self):
         """
+        Assign the variables used to label the properties of the Data2D object.
+
+        In classes inheriting from GenericROI, the variables used to define the
+        boundaries of the Region Of Interest are also set up during __init__.
         """
         self.data = None
         self.err_data = None
@@ -152,8 +209,13 @@ class GenericROI:
 
     def validate_and_assign_data(self, data2d: Data2D = None) -> None:
         """
-        Check that the data supplied valid and assign data variables.
+        Check that the data supplied is valid and assign data to variables.
+        This method must be executed before any further data processing happens
+
+        :param data2d: A Data2D object which is the target of a child class'
+                       data manipulations.
         """
+        # Check that the supplied data2d is valid and usable.
         if not isinstance(data2d, Data2D):
             msg = "Data supplied must be of type Data2D."
             raise TypeError(msg)
@@ -164,6 +226,8 @@ class GenericROI:
         # Only use data which is finite and not masked off
         valid_data = np.isfinite(data2d.data) & data2d.mask
 
+        # Assign properties of the Data2D object to variables for reference
+        # during data processing.
         self.data = data2d.data[valid_data]
         self.err_data = data2d.err_data[valid_data]
         self.q_data = data2d.q_data[valid_data]
@@ -179,17 +243,23 @@ class GenericROI:
 
 class CartesianROI(GenericROI):
     """
-    Base class for manipulators with a rectangular region of interest.
+    Base class for data manipulators with a Cartesian (rectangular) ROI.
     """
 
     def __init__(self, qx_min: float = 0, qx_max: float = 0,
                  qy_min: float = 0, qy_max: float = 0) -> None:
         """
-        TODO - add docstring
+        Assign the variables used to label the properties of the Data2D object.
+        Also establish the upper and lower bounds defining the ROI.
+
+        The units of these parameters are A^-1
+        :param qx_min: Lower bound of the ROI along the Q_x direction.
+        :param qx_max: Upper bound of the ROI along the Q_x direction.
+        :param qy_min: Lower bound of the ROI along the Q_y direction.
+        :param qy_max: Upper bound of the ROI along the Q_y direction.
         """
 
         super().__init__()
-        # Units A^-1
         self.qx_min = qx_min
         self.qx_max = qx_max
         self.qy_min = qy_min
@@ -198,13 +268,22 @@ class CartesianROI(GenericROI):
 
 class PolarROI(GenericROI):
     """
-    Base class for manipulators whose ROI is defined with polar coordinates.
+    Base class for data manipulators with a polar ROI.
     """
 
     def __init__(self, r_min: float, r_max: float,
                  phi_min: float = 0, phi_max: float = 2*np.pi) -> None:
         """
-        TODO - add docstring
+        Assign the variables used to label the properties of the Data2D object.
+        Also establish the upper and lower bounds defining the ROI.
+
+        The units are A^-1 for radial parameters, and radians for anglar ones.
+        :param r_min: Lower bound of the ROI along the Q direction.
+        :param r_max: Upper bound of the ROI along the Q direction.
+        :param phi_min: Lower bound of the ROI along the Phi direction.
+        :param phi_max: Upper bound of the ROI along the Phi direction.
+
+        Note that Phi is measured anti-clockwise from the positive x-axis.
         """
 
         super().__init__()
@@ -222,27 +301,42 @@ class PolarROI(GenericROI):
     def validate_and_assign_data(self, data2d: Data2D = None) -> None:
         """
         Check that the data supplied valid and assign data variables.
+        This method must be executed before any further data processing happens
+
+        :param data2d: A Data2D object which is the target of a child class'
+                       data manipulations.
         """
+
+        # Most validation and pre-processing is taken care of by GenericROI.
         super().validate_and_assign_data(data2d)
+        # Phi data can be calculated from the Cartesian Q coordinates.
         self.phi_data = np.arctan2(self.qy_data, self.qx_data)
 
 
 class Boxsum(CartesianROI):
     """
-    Perform the sum of counts in a 2D region of interest.
+    Compute the sum of the intensity within a rectangular Region Of Interest.
     """
 
     def __init__(self, qx_min: float = 0, qx_max: float = 0,
                  qy_min: float = 0, qy_max: float = 0) -> None:
         """
-        TODO - add docstring
+        Set up the Region of Interest and its boundaries.
+
+        The units of these parameters are A^-1
+        :param qx_min: Lower bound of the ROI along the Q_x direction.
+        :param qx_max: Upper bound of the ROI along the Q_x direction.
+        :param qy_min: Lower bound of the ROI along the Q_y direction.
+        :param qy_max: Upper bound of the ROI along the Q_y direction.
         """
         super().__init__(qx_min=qx_min, qx_max=qx_max,
                          qy_min=qy_min, qy_max=qy_max)
 
     def __call__(self, data2d: Data2D = None) -> float:
         """
-        TODO - add docstring
+        Coordinate data processing operations and return the results.
+
+        :param data2d: The Data2D object for which the sum is calculated.
         """
         self.validate_and_assign_data(data2d)
         total_sum, error, count = self._sum()
@@ -251,7 +345,9 @@ class Boxsum(CartesianROI):
 
     def _sum(self) -> float:
         """
-        TODO - add docstring
+        Determine which data are inside the ROI and compute their sum.
+        Also calculate the error on this calculation and the total number of
+        datapoints in the region.
         """
 
         # Currently the weights are binary, but could be fractional in future
@@ -266,6 +362,8 @@ class Boxsum(CartesianROI):
         weights = x_weights * y_weights
 
         data = weights * self.data
+        # Not certain that the weights should be squared here, I'm just copying
+        # how it was done in the old manipulations.py
         err_squared = weights * weights * self.err_data * self.err_data
 
         total_sum = np.sum(data)
@@ -277,20 +375,28 @@ class Boxsum(CartesianROI):
 
 class Boxavg(Boxsum):
     """
-    Perform the average of counts in a 2D region of interest.
+    Compute the average intensity within a rectangular Region Of Interest.
     """
 
     def __init__(self, qx_min: float = 0, qx_max: float = 0,
                  qy_min: float = 0, qy_max: float = 0) -> None:
         """
-        TODO - add docstring
+        Set up the Region of Interest and its boundaries.
+
+        The units of these parameters are A^-1
+        :param qx_min: Lower bound of the ROI along the Q_x direction.
+        :param qx_max: Upper bound of the ROI along the Q_x direction.
+        :param qy_min: Lower bound of the ROI along the Q_y direction.
+        :param qy_max: Upper bound of the ROI along the Q_y direction.
         """
         super().__init__(qx_min=qx_min, qx_max=qx_max,
                          qy_min=qy_min, qy_max=qy_max)
 
     def __call__(self, data2d: Data2D) -> float:
         """
-        TODO - add docstring
+        Coordinate data processing operations and return the results.
+
+        :param data2d: The Data2D object for which the average is calculated.
         """
         self.validate_and_assign_data(data2d)
         total_sum, error, count = super()._sum()
@@ -300,13 +406,30 @@ class Boxavg(Boxsum):
 
 class SlabX(CartesianROI):
     """
-    Compute average I(Qx) for a region of interest
+    Average I(Q_x, Q_y) along the y direction (within a ROI), giving I(Q_x).
+
+    This class is initialised by specifying the boundaries of the ROI and is
+    called by supplying a Data2D object. It returns a Data1D object.
+    The averaging process can also be thought of as projecting 2D -> 1D.
+
+    There also exists the option to "fold" the ROI, where Q data on opposite
+    sides of the origin but with equal magnitudes are averaged together,
+    resulting in a 1D plot with only positive Q values shown.
     """
 
     def __init__(self, qx_min: float = 0, qx_max: float = 0, qy_min: float = 0,
                  qy_max: float = 0, nbins: int = 100, fold: bool = False):
         """
-        TODO - add docstring
+        Set up the ROI boundaries, the binning of the output 1D data, and fold.
+
+        The units of these parameters are A^-1
+        :param qx_min: Lower bound of the ROI along the Q_x direction.
+        :param qx_max: Upper bound of the ROI along the Q_x direction.
+        :param qy_min: Lower bound of the ROI along the Q_y direction.
+        :param qy_max: Upper bound of the ROI along the Q_y direction.
+        :param nbins: The number of bins data is sorted into along Q_x.
+        :param fold: Whether the two halves of the ROI along Q_x should be
+                     folded together during averaging.
         """
         super().__init__(qx_min=qx_min, qx_max=qx_max,
                          qy_min=qy_min, qy_max=qy_max)
@@ -315,11 +438,17 @@ class SlabX(CartesianROI):
 
     def __call__(self, data2d: Data2D = None) -> Data1D:
         """
-        Compute average I(Qx) for a region of interest
-        :param data2d: Data2D object
-        :return: Data1D object
+        Compute the 1D average of 2D data, projecting along the Q_x axis.
+
+        :param data2d: The Data2D object for which the average is computed.
+        :return: Data1D object for plotting.
         """
         self.validate_and_assign_data(data2d)
+
+        # SlabX is used by SasView's BoxInteractorX, which is designed so that
+        # the ROI is always centred on the origin. If this ever changes, then
+        # the behaviour of fold here will also need to change. Perhaps we could
+        # apply a transformation to the data like the one used in WedgePhi.
 
         if self.fold:
             major_lims = (0, self.qx_max)
@@ -328,8 +457,8 @@ class SlabX(CartesianROI):
             major_lims = (self.qx_min, self.qx_max)
         minor_lims = (self.qy_min, self.qy_max)
 
-        directional_average = DirectionalAverage(major_data=self.qx_data,
-                                                 minor_data=self.qy_data,
+        directional_average = DirectionalAverage(major_axis=self.qx_data,
+                                                 minor_axis=self.qy_data,
                                                  major_lims=major_lims,
                                                  minor_lims=minor_lims,
                                                  nbins=self.nbins)
@@ -341,13 +470,30 @@ class SlabX(CartesianROI):
 
 class SlabY(CartesianROI):
     """
-    Compute average I(Qy) for a region of interest
+    Average I(Q_x, Q_y) along the x direction (within a ROI), giving I(Q_y).
+
+    This class is initialised by specifying the boundaries of the ROI and is
+    called by supplying a Data2D object. It returns a Data1D object.
+    The averaging process can also be thought of as projecting 2D -> 1D.
+
+    There also exists the option to "fold" the ROI, where Q data on opposite
+    sides of the origin but with equal magnitudes are averaged together,
+    resulting in a 1D plot with only positive Q values shown.
     """
 
     def __init__(self, qx_min: float = 0, qx_max: float = 0, qy_min: float = 0,
                  qy_max: float = 0, nbins: int = 100, fold: bool = False):
         """
-        TODO - add docstring
+        Set up the ROI boundaries, the binning of the output 1D data, and fold.
+
+        The units of these parameters are A^-1
+        :param qx_min: Lower bound of the ROI along the Q_x direction.
+        :param qx_max: Upper bound of the ROI along the Q_x direction.
+        :param qy_min: Lower bound of the ROI along the Q_y direction.
+        :param qy_max: Upper bound of the ROI along the Q_y direction.
+        :param nbins: The number of bins data is sorted into along Q_y.
+        :param fold: Whether the two halves of the ROI along Q_y should be
+                     folded together during averaging.
         """
         super().__init__(qx_min=qx_min, qx_max=qx_max,
                          qy_min=qy_min, qy_max=qy_max)
@@ -356,11 +502,17 @@ class SlabY(CartesianROI):
 
     def __call__(self, data2d: Data2D = None) -> Data1D:
         """
-        Compute average I(Qy) for a region of interest
-        :param data2d: Data2D object
-        :return: Data1D object
+        Compute the 1D average of 2D data, projecting along the Q_y axis.
+
+        :param data2d: The Data2D object for which the average is computed.
+        :return: Data1D object for plotting.
         """
         self.validate_and_assign_data(data2d)
+
+        # SlabY is used by SasView's BoxInteractorY, which is designed so that
+        # the ROI is always centred on the origin. If this ever changes, then
+        # the behaviour of fold here will also need to change. Perhaps we could
+        # apply a transformation to the data like the one used in WedgePhi.
 
         if self.fold:
             major_lims = (0, self.qy_max)
@@ -369,8 +521,8 @@ class SlabY(CartesianROI):
             major_lims = (self.qy_min, self.qy_max)
         minor_lims = (self.qx_min, self.qx_max)
 
-        directional_average = DirectionalAverage(major_data=self.qy_data,
-                                                 minor_data=self.qx_data,
+        directional_average = DirectionalAverage(major_axis=self.qy_data,
+                                                 minor_axis=self.qx_data,
                                                  major_lims=major_lims,
                                                  minor_lims=minor_lims,
                                                  nbins=self.nbins)
@@ -382,30 +534,41 @@ class SlabY(CartesianROI):
 
 class CircularAverage(PolarROI):
     """
-    Perform circular averaging on 2D data
+    Calculate I(|Q|) by circularly averaging 2D data between 2 radial limits.
 
-    The data returned is the distribution of counts
-    as a function of Q
+    This class is initialised by specifying lower and upper limits on the
+    magnitude of Q values to consider during the averaging, though currently
+    SasView always calls this class using the full range of data. When called,
+    this class is supplied with a Data2D object. It returns a Data1D object
+    where intensity is given as a function of Q only.
     """
 
     def __init__(self, r_min: float, r_max: float, nbins: int = 100) -> None:
         """
-        TODO - add docstring
+        Set up the lower and upper radial limits as well as the number of bins.
+
+        The units are A^-1 for the radial parameters.
+        :param r_min: Lower limit for |Q| values to use during averaging.
+        :param r_max: Upper limit for |Q| values to use during averaging.
+        :param nbins: The number of bins data is sorted into along |Q| the axis
         """
-        super().__init__(r_min=r_min, r_max=r_max, phi_min=0, phi_max=2*np.pi)
+        super().__init__(r_min=r_min, r_max=r_max)
         self.nbins = nbins
 
     def __call__(self, data2d: Data2D = None) -> Data1D:
         """
-        TODO - add docstring
+        Compute the 1D average of 2D data, projecting along the Q axis.
+
+        :param data2d: The Data2D object for which the average is computed.
+        :return: Data1D object for plotting.
         """
         self.validate_and_assign_data(data2d)
 
         # Averaging takes place between radial limits
         major_lims = (self.r_min, self.r_max)
-        # Average over the full angular range
-        directional_average = DirectionalAverage(major_data=self.q_data,
-                                                 minor_data=self.phi_data,
+        # minor_lims is None because a full-circle angular range is used
+        directional_average = DirectionalAverage(major_axis=self.q_data,
+                                                 minor_axis=self.phi_data,
                                                  major_lims=major_lims,
                                                  minor_lims=None,
                                                  nbins=self.nbins)
@@ -417,35 +580,41 @@ class CircularAverage(PolarROI):
 
 class Ring(PolarROI):
     """
-    Defines a ring on a 2D data set.
-    The ring is defined by r_min, r_max, and
-    the position of the center of the ring.
+    Calculate I(φ) by radially averaging 2D data between 2 radial limits.
 
-    The data returned is the distribution of counts
-    around the ring as a function of phi.
-
-    Phi_min and phi_max should be defined between 0 and 2*pi
-    in anti-clockwise starting from the x- axis on the left-hand side
+    This class is initialised by specifying lower and upper limits on the
+    magnitude of Q values to consider during the averaging. When called,
+    this class is supplied with a Data2D object. It returns a Data1D object.
+    This Data1D object gives intensity as a function of the angle from the
+    positive x-axis, φ, only.
     """
 
     def __init__(self, r_min: float, r_max: float, nbins: int = 100) -> None:
         """
-        TODO - add docstring
+        Set up the lower and upper radial limits as well as the number of bins.
+
+        The units are A^-1 for the radial parameters.
+        :param r_min: Lower limit for |Q| values to use during averaging.
+        :param r_max: Upper limit for |Q| values to use during averaging.
+        :param nbins: The number of bins data is sorted into along Phi the axis
         """
-        super().__init__(r_min=r_min, r_max=r_max, phi_min=0, phi_max=2*np.pi)
+        super().__init__(r_min=r_min, r_max=r_max)
         self.nbins = nbins
 
     def __call__(self, data2d: Data2D = None) -> Data1D:
         """
-        TODO - add docstring
+        Compute the 1D average of 2D data, projecting along the Phi axis.
+
+        :param data2d: The Data2D object for which the average is computed.
+        :return: Data1D object for plotting.
         """
         self.validate_and_assign_data(data2d)
 
         # Averaging takes place between radial limits
         minor_lims = (self.r_min, self.r_max)
-        # Average over the full angular range
-        directional_average = DirectionalAverage(major_data=self.phi_data,
-                                                 minor_data=self.q_data,
+        # major_lims is None because a full-circle angular range is used
+        directional_average = DirectionalAverage(major_axis=self.phi_data,
+                                                 minor_axis=self.q_data,
                                                  major_lims=None,
                                                  minor_lims=minor_lims,
                                                  nbins=self.nbins)
@@ -457,20 +626,39 @@ class Ring(PolarROI):
 
 class SectorQ(PolarROI):
     """
-    Sector average as a function of Q for both wings. setting the _Sector.fold
-    attribute determines whether or not the two sectors are averaged together
-    (folded over) or separate.  In the case of separate (not folded), the
-    qs for the "minor wing" are arbitrarily set to a negative value.
-    I(Q) is returned and the data is averaged over phi.
+    Project I(Q, φ) data onto I(Q) within a region defined by Cartesian limits.
 
-    A sector is defined by r_min, r_max, phi_min, phi_max.
-    where r_min, r_max, phi_min, phi_max >0.
-    The number of bins in Q also has to be defined.
+    The projection is computed by averaging together datapoints with the same
+    angle φ (so long as they are within the ROI), measured anticlockwise from
+    the positive x-axis.
+
+    This class is initialised by specifying lower and upper limits on both the
+    magnitude of Q and the angle φ. These four parameters specify the primary
+    Region Of Interest, however there is a secondary ROI with the same |Q|
+    values on the opposite side of the origin (φ + π). How this secondary ROI
+    is treated depends on the value of the `fold` parameter. If fold is set to
+    True, data on opposite sides of the origin are averaged together and the
+    results are plotted against positive values of Q. If fold is set to False,
+    the data from the two regions are graphed separeately, with the secondary
+    ROI data labelled using negative Q values.
+
+    When called, this class is supplied with a Data2D object. It returns a
+    Data1D object where intensity is given as a function of Q only.
     """
 
     def __init__(self, r_min: float, r_max: float, phi_min: float,
                  phi_max: float, nbins: int = 100, fold: bool = True) -> None:
         """
+        Set up the ROI boundaries, the binning of the output 1D data, and fold.
+
+        The units are A^-1 for radial parameters, and radians for anglar ones.
+        :param r_min: Lower limit for |Q| values to use during averaging.
+        :param r_max: Upper limit for |Q| values to use during averaging.
+        :param phi_min: Lower limit for φ values (in the primary ROI).
+        :param phi_max: Upper limit for φ values (in the primary ROI).
+        :param nbins: The number of bins data is sorted into along the |Q| axis
+        :param fold: Whether the primary and secondary ROIs should be folded
+                     together during averaging.
         """
         super().__init__(r_min=r_min, r_max=r_max,
                          phi_min=phi_min, phi_max=phi_max)
@@ -479,10 +667,15 @@ class SectorQ(PolarROI):
 
     def __call__(self, data2d: Data2D = None) -> Data1D:
         """
+        Compute the 1D average of 2D data, projecting along the Q_y axis.
+
+        :param data2d: The Data2D object for which the average is computed.
+        :return: Data1D object for plotting.
         """
         self.validate_and_assign_data(data2d)
 
-        # Transform all angles to the range [0,2π), where phi_min is at zero.
+        # Transform all angles to the range [0,2π) where phi_min is at zero,
+        # eliminating errors when the ROI straddles the 2π -> 0 discontinuity.
         # We won't need to convert back later because we're plotting against Q.
         phi_offset = self.phi_min
         self.phi_min = 0.0
@@ -494,13 +687,13 @@ class SectorQ(PolarROI):
         # Secondary region of interest covers angles on opposite side of origin
         minor_lims_alt = (self.phi_min + np.pi, self.phi_max + np.pi)
 
-        primary_region = DirectionalAverage(major_data=self.q_data,
-                                            minor_data=self.phi_data,
+        primary_region = DirectionalAverage(major_axis=self.q_data,
+                                            minor_axis=self.phi_data,
                                             major_lims=major_lims,
                                             minor_lims=minor_lims,
                                             nbins=self.nbins)
-        secondary_region = DirectionalAverage(major_data=self.q_data,
-                                              minor_data=self.phi_data,
+        secondary_region = DirectionalAverage(major_axis=self.q_data,
+                                              minor_axis=self.phi_data,
                                               major_lims=major_lims,
                                               minor_lims=minor_lims_alt,
                                               nbins=self.nbins)
@@ -543,6 +736,7 @@ class SectorQ(PolarROI):
             data1d = Data1D(x=combined_q[finite], y=average_intensity[finite],
                             dy=combined_err[finite])
         else:
+            # The secondary ROI is labelled with negative Q values.
             combined_q = np.append(np.flip(-1 * secondary_q), primary_q)
             combined_intensity = np.append(np.flip(secondary_I), primary_I)
             combined_error = np.append(np.flip(secondary_err), primary_err)
@@ -554,12 +748,29 @@ class SectorQ(PolarROI):
 
 class WedgeQ(PolarROI):
     """
-    TODO - add docstring
+    Project I(Q, φ) data onto I(Q) within a region defined by Cartesian limits.
+
+    The projection is computed by averaging together datapoints with the same
+    angle φ (so long as they are within the ROI), measured anticlockwise from
+    the positive x-axis.
+
+    This class is initialised by specifying lower and upper limits on both the
+    magnitude of Q and the angle φ.
+    When called, this class is supplied with a Data2D object. It returns a
+    Data1D object where intensity is given as a function of Q only.
     """
 
     def __init__(self, r_min: float, r_max: float, phi_min: float,
                  phi_max: float, nbins: int = 100) -> None:
         """
+        Set up the ROI boundaries, and the binning of the output 1D data.
+
+        The units are A^-1 for radial parameters, and radians for anglar ones.
+        :param r_min: Lower limit for |Q| values to use during averaging.
+        :param r_max: Upper limit for |Q| values to use during averaging.
+        :param phi_min: Lower limit for φ values (in the primary ROI).
+        :param phi_max: Upper limit for φ values (in the primary ROI).
+        :param nbins: The number of bins data is sorted into along the |Q| axis
         """
         super().__init__(r_min=r_min, r_max=r_max,
                          phi_min=phi_min, phi_max=phi_max)
@@ -567,10 +778,15 @@ class WedgeQ(PolarROI):
 
     def __call__(self, data2d: Data2D = None) -> Data1D:
         """
+        Compute the 1D average of 2D data, projecting along the Q_y axis.
+
+        :param data2d: The Data2D object for which the average is computed.
+        :return: Data1D object for plotting.
         """
         self.validate_and_assign_data(data2d)
 
-        # Transform all angles to the range [0,2π), where phi_min is at zero.
+        # Transform all angles to the range [0,2π) where phi_min is at zero,
+        # eliminating errors when the ROI straddles the 2π -> 0 discontinuity.
         # We won't need to convert back later because we're plotting against Q.
         phi_offset = self.phi_min
         self.phi_min = 0.0
@@ -585,8 +801,8 @@ class WedgeQ(PolarROI):
         else:
             minor_lims = (self.phi_min, self.phi_max)
 
-        directional_average = DirectionalAverage(major_data=self.q_data,
-                                                 minor_data=self.phi_data,
+        directional_average = DirectionalAverage(major_axis=self.q_data,
+                                                 minor_axis=self.phi_data,
                                                  major_lims=major_lims,
                                                  minor_lims=minor_lims,
                                                  nbins=self.nbins)
@@ -598,12 +814,29 @@ class WedgeQ(PolarROI):
 
 class WedgePhi(PolarROI):
     """
-    TODO - add docstring
+    Project I(Q, φ) data onto I(φ) within a region defined by Cartesian limits.
+
+    The projection is computed by averaging together datapoints with the same
+    Q value (so long as they are within the ROI).
+
+    This class is initialised by specifying lower and upper limits on both the
+    magnitude of Q and the angle φ, measured anticlockwise from the positive
+    x-axis.
+    When called, this class is supplied with a Data2D object. It returns a
+    Data1D object where intensity is given as a function of Q only.
     """
 
     def __init__(self, r_min: float, r_max: float, phi_min: float,
                  phi_max: float, nbins: int = 100) -> None:
         """
+        Set up the ROI boundaries, and the binning of the output 1D data.
+
+        The units are A^-1 for radial parameters, and radians for anglar ones.
+        :param r_min: Lower limit for |Q| values to use during averaging.
+        :param r_max: Upper limit for |Q| values to use during averaging.
+        :param phi_min: Lower limit for φ values to use during averaging.
+        :param phi_max: Upper limit for φ values to use during averaging.
+        :param nbins: The number of bins data is sorted into along the φ axis.
         """
         super().__init__(r_min=r_min, r_max=r_max,
                          phi_min=phi_min, phi_max=phi_max)
@@ -611,12 +844,16 @@ class WedgePhi(PolarROI):
 
     def __call__(self, data2d: Data2D = None) -> Data1D:
         """
-        TODO - add docstring
+        Compute the 1D average of 2D data, projecting along the Q_y axis.
+
+        :param data2d: The Data2D object for which the average is computed.
+        :return: Data1D object for plotting.
         """
         self.validate_and_assign_data(data2d)
 
-        # Transform all angles to the range [0,2π), where phi_min is at zero.
-        # Remember to transform back afterwards
+        # Transform all angles to the range [0,2π) where phi_min is at zero,
+        # eliminating errors when the ROI straddles the 2π -> 0 discontinuity.
+        # Remember to transform back afterwards as we're plotting against phi.
         phi_offset = self.phi_min
         self.phi_min = 0.0
         self.phi_max = (self.phi_max - phi_offset) % (2 * np.pi)
@@ -630,8 +867,8 @@ class WedgePhi(PolarROI):
             major_lims = (self.phi_min, self.phi_max)
         minor_lims = (self.r_min, self.r_max)
 
-        directional_average = DirectionalAverage(major_data=self.phi_data,
-                                                 minor_data=self.q_data,
+        directional_average = DirectionalAverage(major_axis=self.phi_data,
+                                                 minor_axis=self.q_data,
                                                  major_lims=major_lims,
                                                  minor_lims=minor_lims,
                                                  nbins=self.nbins)

--- a/sasdata/data_util/new_manipulations.py
+++ b/sasdata/data_util/new_manipulations.py
@@ -1,6 +1,3 @@
-from abc import ABC, abstractmethod
-from typing import Union
-
 import numpy as np
 
 from sasdata.dataloader.data_info import Data1D, Data2D
@@ -13,6 +10,8 @@ def weights_for_interval(array, l_bound, u_bound, interval_type='half-open'):
     fractional values instead. These will depend on how close the array value
     is to being within the interval defined.
     """
+    # These checks could be modified to return fractional bin weights.
+    # The last value in the binning range must be included for to pass utests
     if interval_type == 'half-open':
         in_range = (l_bound <= array) & (array < u_bound)
     elif interval_type == 'closed':
@@ -24,51 +23,157 @@ def weights_for_interval(array, l_bound, u_bound, interval_type='half-open'):
     return np.asarray(in_range, dtype=int)
 
 
-class Binning:
+class DirectionalAverage:
     """
-    TODO - add docstring
+    TODO - write a docstring
     """
 
-    def __init__(self, min_value, max_value, nbins, base=None):
+    def __init__(self, major_data, minor_data, major_lims=None,
+                 minor_lims=None, nbins=100):
         """
         """
-        self.minimum = min_value
-        self.maximum = max_value
-        self.nbins = nbins
-        self.base = base
-        self.bin_width = (max_value - min_value) / nbins
+        if any(not isinstance(data, (list, np.ndarray)) for
+               data in (major_data, minor_data)):
+            msg = "Must provide major & minor coordinate arrays for binning."
+            raise ValueError(msg)
+        if any(lims is not None and len(lims) != 2 for
+               lims in (major_lims, minor_lims)):
+            msg = "Limits arrays must have 2 elements or be NoneType"
+            raise ValueError(msg)
+        if not isinstance(nbins, int):
+            msg = "Parameter 'nbins' must be an integer"
+            raise TypeError(msg)
 
-    def get_index(self, value: float) -> int:
-        """
-        """
-        if self.base:
-            numerator = (np.log(value) - np.log(self.minimum)) \
-                / np.log(self.base)
-            denominator = (np.log(self.maximum) - np.log(self.minimum)) \
-                / np.log(self.base)
+        self.major_data = np.asarray(major_data)
+        self.minor_data = np.asarray(minor_data)
+        if major_lims is None:
+            self.major_lims = (self.major_data.min(), self.major_data.max())
         else:
-            numerator = value - self.minimum
-            denominator = self.maximum - self.minimum
+            self.major_lims = major_lims
+        if minor_lims is None:
+            self.minor_lims = (self.minor_data.min(), self.minor_data.max())
+        else:
+            self.minor_lims = minor_lims
+        self.nbins = nbins
 
+    @property
+    def bin_width(self):
+        """
+        Return the bin width
+        """
+        return (self.major_lims[1] - self.major_lims[0]) / self.nbins
+
+    def get_bin_interval(self, bin_number):
+        """
+        Return the upper and lower limits defining a given bin
+        """
+        bin_start = self.major_lims[0] + bin_number * self.bin_width
+        bin_end = self.major_lims[0] + (bin_number + 1) * self.bin_width
+
+        return bin_start, bin_end
+
+    def get_bin_index(self, value):
+        """
+        """
+        numerator = value - self.major_lims[0]
+        denominator = self.major_lims[1] - self.major_lims[0]
         bin_index = int(np.floor(self.nbins * numerator / denominator))
 
-        # Bins are indexed from 0 to nbins-1, so this check protects against
-        # out-of-range indices when value == maximum.
+        # Bins are indexed from 0 to nbins-1, so tihs check protects against
+        # out-of-range indices when value == self.major_lims[1]
         if bin_index == self.nbins:
             bin_index -= 1
 
         return bin_index
 
-    def get_interval(self, bin_number: int) -> float:
+    def compute_weights(self):
         """
         """
-        start = self.minimum + self.bin_width * bin_number
-        stop = self.minimum + self.bin_width * (bin_number + 1)
+        major_weights = np.zeros((self.nbins, self.major_data.size))
+        for m in range(self.nbins):
+            # Include the value at the end of the binning range, but in
+            # general use half-open intervals so each value begins in only
+            # one bin.
+            if m == self.nbins - 1:
+                interval = 'closed'
+            else:
+                interval = 'half-open'
+            bin_start, bin_end = self.get_bin_interval(bin_number=m)
+            major_weights[m] = weights_for_interval(array=self.major_data,
+                                                    l_bound=bin_start,
+                                                    u_bound=bin_end,
+                                                    interval_type=interval)
+        minor_weights = weights_for_interval(array=self.minor_data,
+                                             l_bound=self.minor_lims[0],
+                                             u_bound=self.minor_lims[1],
+                                             interval_type='closed')
+        return major_weights * minor_weights
 
-        return start, stop
+    def __call__(self, data, err_data):
+        """
+        """
+        weights = self.compute_weights()
+
+        x_axis_values = np.sum(weights * self.major_data, axis=1)
+        intensity = np.sum(weights * data, axis=1)
+        errs_squared = np.sum((weights * err_data)**2, axis=1)
+        bin_counts = np.sum(weights, axis=1)
+
+        errors = np.sqrt(errs_squared)
+        x_axis_values /= bin_counts
+        intensity /= bin_counts
+        errors /= bin_counts
+
+        finite = (np.isfinite(x_axis_values) & np.isfinite(intensity))
+        if not finite.any():
+            msg = "Average Error: No points inside ROI to average..."
+            raise ValueError(msg)
+
+        return x_axis_values[finite], intensity[finite], errors[finite]
 
 
-class CartesianROI(ABC):
+class GenericROI:
+    """
+    TODO - add docstring
+    """
+
+    def __init__(self):
+        """
+        """
+        self.data = None
+        self.err_data = None
+        self.q_data = None
+        self.qx_data = None
+        self.qy_data = None
+
+    def validate_and_assign_data(self, data2d: Data2D = None) -> None:
+        """
+        Check that the data supplied valid and assign data variables.
+        """
+        if not isinstance(data2d, Data2D):
+            msg = "Data supplied must be of type Data2D."
+            raise TypeError(msg)
+        if len(data2d.detector) > 1:
+            msg = f"Invalid number of detectors: {len(data2d.detector)}"
+            raise ValueError(msg)
+
+        # Only use data which is finite and not masked off
+        valid_data = np.isfinite(data2d.data) & data2d.mask
+
+        self.data = data2d.data[valid_data]
+        self.err_data = data2d.err_data[valid_data]
+        self.q_data = data2d.q_data[valid_data]
+        self.qx_data = data2d.qx_data[valid_data]
+        self.qy_data = data2d.qy_data[valid_data]
+
+        # No points should have zero error, if they do then assume the error is
+        # the square root of the data. This code was added to replicate
+        # previous functionality. It's a bit dodgy, so feel free to remove.
+        self.err_data[self.err_data == 0] = \
+            np.sqrt(np.abs(self.data[self.err_data == 0]))
+
+
+class CartesianROI(GenericROI):
     """
     Base class for manipulators with a rectangular region of interest.
     """
@@ -79,126 +184,43 @@ class CartesianROI(ABC):
         TODO - add docstring
         """
 
+        super().__init__()
         # Units A^-1
         self.qx_min = qx_min
         self.qx_max = qx_max
         self.qy_min = qy_min
         self.qy_max = qy_max
 
-        # Define data related variables
-        self.data = None
-        self.err_data = None
-        self.qx_data = None
-        self.qy_data = None
-        self.mask_data = None
 
-    @abstractmethod
-    def __call__(self, data2d: Data2D = None) -> Union[float, Data1D]:
-        """
-        TODO - add docstring
-        """
-        return
-
-    # This method might be better placed in a parent class
-    def validate_and_assign_data(self, data2d: Data2D = None) -> None:
-        """
-        Check that the data supplied valid and assign data variables.
-        """
-        if not isinstance(data2d, Data2D):
-            msg = "Data supplied must be of type Data2D."
-            raise TypeError(msg)
-        if len(data2d.detector) > 1:
-            msg = f"Invalid number of detectors: {len(data2d.detector)}"
-            raise ValueError(msg)
-
-        finite_data = np.isfinite(data2d.data)
-        self.data = data2d.data[finite_data]
-        self.err_data = data2d.err_data[finite_data]
-        self.qx_data = data2d.qx_data[finite_data]
-        self.qy_data = data2d.qy_data[finite_data]
-        self.mask_data = data2d.mask[finite_data]
-
-        # No points should have zero error, if they do then assume the error is
-        # the square root of the data.
-        self.err_data[self.err_data == 0] = \
-            np.sqrt(np.abs(self.data[self.err_data == 0]))
-
-    @property
-    def roi_mask(self):
-        """
-        Return a boolean array listing the elements of self.data which are
-        inside the ROI. This property should only be accessed after
-        CartesianROI has been called.
-        """
-        if any(data is None for data in [self.qx_data, self.qy_data,
-                                         self.mask_data]):
-            raise RuntimeError
-
-        within_x_lims = (self.qx_data >= self.qx_min) & \
-                        (self.qx_data <= self.qx_max)
-        within_y_lims = (self.qy_data >= self.qy_min) & \
-                        (self.qy_data <= self.qy_max)
-
-        # Don't return masked-off data
-        return within_x_lims & within_y_lims & self.mask_data
-
-
-class PolarROI(ABC):
+class PolarROI(GenericROI):
     """
     Base class for manipulators whose ROI is defined with polar coordinates.
     """
 
-    def __init__(self, r_min: float = 0, r_max: float = 1000,
+    def __init__(self, r_min: float, r_max: float,
                  phi_min: float = 0, phi_max: float = 2*np.pi) -> None:
         """
         TODO - add docstring
         """
 
+        super().__init__()
+        self.phi_data = None
+
+        if r_min >= r_max:
+            msg = "Minimum radius cannot be greater than maximum radius."
+            raise ValueError(msg)
         # Units A^-1 for radii, radians for angles
         self.r_min = r_min
         self.r_max = r_max
         self.phi_min = phi_min
         self.phi_max = phi_max
 
-        # Define data related variables
-        self.data = None
-        self.err_data = None
-        self.q_data = None
-        self.qx_data = None
-        self.qy_data = None
-        self.mask_data = None
-
-    @abstractmethod
-    def __call__(self, data2d: Data2D = None) -> Union[float, Data1D]:
-        """
-        TODO - add docstring
-        """
-        return
-
-    # This method might be better placed in a parent class
     def validate_and_assign_data(self, data2d: Data2D = None) -> None:
         """
         Check that the data supplied valid and assign data variables.
         """
-        if not isinstance(data2d, Data2D):
-            msg = "Data supplied must be of type Data2D."
-            raise TypeError(msg)
-        if len(data2d.detector) > 1:
-            msg = f"Invalid number of detectors: {len(data2d.detector)}"
-            raise ValueError(msg)
-
-        finite_data = np.isfinite(data2d.data)
-        self.data = data2d.data[finite_data]
-        self.err_data = data2d.err_data[finite_data]
-        self.q_data = data2d.q_data[finite_data]
-        self.qx_data = data2d.qx_data[finite_data]
-        self.qy_data = data2d.qy_data[finite_data]
-        self.mask_data = data2d.mask[finite_data]
-
-        # No points should have zero error, if they do then assume the error is
-        # the square root of the data.
-        self.err_data[self.err_data == 0] = \
-            np.sqrt(np.abs(self.data[self.err_data == 0]))
+        super().validate_and_assign_data(data2d)
+        self.phi_data = np.arctan2(self.qy_data, self.qx_data)
 
 
 class Boxsum(CartesianROI):
@@ -208,12 +230,15 @@ class Boxsum(CartesianROI):
 
     def __init__(self, qx_min: float = 0, qx_max: float = 0,
                  qy_min: float = 0, qy_max: float = 0) -> None:
+        """
+        TODO - add docstring
+        """
         super().__init__(qx_min=qx_min, qx_max=qx_max,
                          qy_min=qy_min, qy_max=qy_max)
 
     def __call__(self, data2d: Data2D = None) -> float:
         """
-        Placeholder
+        TODO - add docstring
         """
         self.validate_and_assign_data(data2d)
         total_sum, error, count = self._sum()
@@ -226,7 +251,15 @@ class Boxsum(CartesianROI):
         """
 
         # Currently the weights are binary, but could be fractional in future
-        weights = self.roi_mask.astype(int)
+        x_weights = weights_for_interval(array=self.qx_data,
+                                         l_bound=self.qx_min,
+                                         u_bound=self.qx_max,
+                                         interval_type='closed')
+        y_weights = weights_for_interval(array=self.qy_data,
+                                         l_bound=self.qy_min,
+                                         u_bound=self.qy_max,
+                                         interval_type='closed')
+        weights = x_weights * y_weights
 
         data = weights * self.data
         err_squared = weights * weights * self.err_data * self.err_data
@@ -245,6 +278,9 @@ class Boxavg(Boxsum):
 
     def __init__(self, qx_min: float = 0, qx_max: float = 0,
                  qy_min: float = 0, qy_max: float = 0) -> None:
+        """
+        TODO - add docstring
+        """
         super().__init__(qx_min=qx_min, qx_max=qx_max,
                          qy_min=qy_min, qy_max=qy_max)
 
@@ -258,87 +294,20 @@ class Boxavg(Boxsum):
         return (total_sum / count), (error / count)
 
 
-class _Slab(CartesianROI):
+class SlabX(CartesianROI):
     """
-    Compute average I(Q) for a region of interest
+    Compute average I(Qx) for a region of interest
     """
 
     def __init__(self, qx_min: float = 0, qx_max: float = 0, qy_min: float = 0,
                  qy_max: float = 0, nbins: int = 100, fold: bool = False):
+        """
+        TODO - add docstring
+        """
         super().__init__(qx_min=qx_min, qx_max=qx_max,
                          qy_min=qy_min, qy_max=qy_max)
         self.nbins = nbins
         self.fold = fold
-
-    def __call__(self, data2d: Data2D = None) -> Data1D:
-        pass
-
-    def _avg(self, data2d: Data2D, major_axis: str) -> Data1D:
-        """
-        TODO - add docstring
-        """
-        self.validate_and_assign_data(data2d)
-
-        if major_axis == 'x':
-            q_major = self.qx_data
-            q_minor = self.qy_data
-            minor_lims = (self.qy_min, self.qy_max)
-            binning = Binning(min_value=0 if self.fold else self.qx_min,
-                              max_value=self.qx_max, nbins=self.nbins)
-        elif major_axis == 'y':
-            q_major = self.qy_data
-            q_minor = self.qx_data
-            minor_lims = (self.qx_min, self.qx_max)
-            binning = Binning(min_value=0 if self.fold else self.qy_min,
-                              max_value=self.qy_max, nbins=self.nbins)
-        else:
-            msg = f"Unrecognised axis: {major_axis}"
-            raise ValueError(msg)
-
-        if self.fold:
-            q_major = np.abs(q_major)
-
-        major_weights = np.zeros((self.nbins, q_major.size))
-        for m in range(self.nbins):
-            # Include the value at the end of the binning range, but otherwise
-            # use half-open intervals so each value belongs in only one bin.
-            if m == self.nbins - 1:
-                interval = 'closed'
-            else:
-                interval = 'half-open'
-            bin_start, bin_end = binning.get_interval(bin_number=m)
-            major_weights[m] \
-                = weights_for_interval(array=q_major, l_bound=bin_start,
-                                       u_bound=bin_end,
-                                       interval_type=interval)
-        minor_weights = weights_for_interval(array=q_minor,
-                                             l_bound=minor_lims[0],
-                                             u_bound=minor_lims[1],
-                                             interval_type='closed')
-        weights = major_weights * minor_weights
-
-        q_values = np.sum(weights * q_major, axis=1)
-        intensity = np.sum(weights * self.data, axis=1)
-        errs_squared = np.sum((weights * self.err_data)**2, axis=1)
-        bin_counts = np.sum(weights, axis=1)
-
-        errors = np.sqrt(errs_squared)
-        q_values /= bin_counts
-        intensity /= bin_counts
-        errors /= bin_counts
-
-        finite = (np.isfinite(q_values) & np.isfinite(intensity))
-        if not finite.any():
-            msg = "Average Error: No points inside ROI to average..."
-            raise ValueError(msg)
-
-        return Data1D(x=q_values[finite], y=intensity[finite], dy=errors[finite])
-
-
-class SlabX(_Slab):
-    """
-    Compute average I(Qx) for a region of interest
-    """
 
     def __call__(self, data2d: Data2D = None) -> Data1D:
         """
@@ -346,13 +315,40 @@ class SlabX(_Slab):
         :param data2d: Data2D object
         :return: Data1D object
         """
-        return self._avg(data2d, 'x')
+        self.validate_and_assign_data(data2d)
+
+        if self.fold:
+            major_lims = (0, self.qx_max)
+            self.qx_data = np.abs(self.qx_data)
+        else:
+            major_lims = (self.qx_min, self.qx_max)
+        minor_lims = (self.qy_min, self.qy_max)
+
+        directional_average = DirectionalAverage(major_data=self.qx_data,
+                                                 minor_data=self.qy_data,
+                                                 major_lims=major_lims,
+                                                 minor_lims=minor_lims,
+                                                 nbins=self.nbins)
+        qx_data, intensity, error = \
+            directional_average(data=self.data, err_data=self.err_data)
+
+        return Data1D(x=qx_data, y=intensity, dy=error)
 
 
-class SlabY(_Slab):
+class SlabY(CartesianROI):
     """
     Compute average I(Qy) for a region of interest
     """
+
+    def __init__(self, qx_min: float = 0, qx_max: float = 0, qy_min: float = 0,
+                 qy_max: float = 0, nbins: int = 100, fold: bool = False):
+        """
+        TODO - add docstring
+        """
+        super().__init__(qx_min=qx_min, qx_max=qx_max,
+                         qy_min=qy_min, qy_max=qy_max)
+        self.nbins = nbins
+        self.fold = fold
 
     def __call__(self, data2d: Data2D = None) -> Data1D:
         """
@@ -360,5 +356,251 @@ class SlabY(_Slab):
         :param data2d: Data2D object
         :return: Data1D object
         """
-        return self._avg(data2d, 'y')
+        self.validate_and_assign_data(data2d)
+
+        if self.fold:
+            major_lims = (0, self.qy_max)
+            self.qy_data = np.abs(self.qy_data)
+        else:
+            major_lims = (self.qy_min, self.qy_max)
+        minor_lims = (self.qx_min, self.qx_max)
+
+        directional_average = DirectionalAverage(major_data=self.qy_data,
+                                                 minor_data=self.qx_data,
+                                                 major_lims=major_lims,
+                                                 minor_lims=minor_lims,
+                                                 nbins=self.nbins)
+        qy_data, intensity, error = \
+            directional_average(data=self.data, err_data=self.err_data)
+
+        return Data1D(x=qy_data, y=intensity, dy=error)
+
+
+class CircularAverage(PolarROI):
+    """
+    Perform circular averaging on 2D data
+
+    The data returned is the distribution of counts
+    as a function of Q
+    """
+
+    def __init__(self, r_min: float, r_max: float, nbins: int = 100) -> None:
+        """
+        TODO - add docstring
+        """
+        super().__init__(r_min=r_min, r_max=r_max, phi_min=0, phi_max=2*np.pi)
+        self.nbins = nbins
+
+    def __call__(self, data2d: Data2D = None) -> Data1D:
+        """
+        TODO - add docstring
+        """
+        self.validate_and_assign_data(data2d)
+
+        # Averaging takes place between radial limits
+        major_lims = (self.r_min, self.r_max)
+        # Average over the full angular range
+        directional_average = DirectionalAverage(major_data=self.q_data,
+                                                 minor_data=self.phi_data,
+                                                 major_lims=major_lims,
+                                                 minor_lims=None,
+                                                 nbins=self.nbins)
+        q_data, intensity, error = \
+            directional_average(data=self.data, err_data=self.err_data)
+
+        return Data1D(x=q_data, y=intensity, dy=error)
+
+
+class Ring(PolarROI):
+    """
+    Defines a ring on a 2D data set.
+    The ring is defined by r_min, r_max, and
+    the position of the center of the ring.
+
+    The data returned is the distribution of counts
+    around the ring as a function of phi.
+
+    Phi_min and phi_max should be defined between 0 and 2*pi
+    in anti-clockwise starting from the x- axis on the left-hand side
+    """
+
+    def __init__(self, r_min: float, r_max: float, nbins: int = 100) -> None:
+        """
+        TODO - add docstring
+        """
+        super().__init__(r_min=r_min, r_max=r_max, phi_min=0, phi_max=2*np.pi)
+        self.nbins = nbins
+
+    def __call__(self, data2d: Data2D = None) -> Data1D:
+        """
+        TODO - add docstring
+        """
+        self.validate_and_assign_data(data2d)
+
+        # Averaging takes place between radial limits
+        minor_lims = (self.r_min, self.r_max)
+        # Average over the full angular range
+        directional_average = DirectionalAverage(major_data=self.phi_data,
+                                                 minor_data=self.q_data,
+                                                 major_lims=None,
+                                                 minor_lims=minor_lims,
+                                                 nbins=self.nbins)
+        phi_data, intensity, error = \
+            directional_average(data=self.data, err_data=self.err_data)
+
+        return Data1D(x=phi_data, y=intensity, dy=error)
+
+
+class SectorQ(PolarROI):
+    """
+    Sector average as a function of Q for both wings. setting the _Sector.fold
+    attribute determines whether or not the two sectors are averaged together
+    (folded over) or separate.  In the case of separate (not folded), the
+    qs for the "minor wing" are arbitrarily set to a negative value.
+    I(Q) is returned and the data is averaged over phi.
+
+    A sector is defined by r_min, r_max, phi_min, phi_max.
+    where r_min, r_max, phi_min, phi_max >0.
+    The number of bins in Q also has to be defined.
+    """
+
+    def __init__(self, r_min: float, r_max: float, phi_min: float,
+                 phi_max: float, nbins: int = 100, fold: bool = True) -> None:
+        """
+        """
+        super().__init__(r_min=r_min, r_max=r_max,
+                         phi_min=phi_min, phi_max=phi_max)
+        self.nbins = nbins
+        self.fold = fold
+
+    def __call__(self, data2d: Data2D = None) -> Data1D:
+        """
+        """
+        self.validate_and_assign_data(data2d)
+
+        # Transform all angles to the range [0,2π), where phi_min is at zero.
+        # We won't need to convert back later because we're plotting against Q.
+        phi_offset = self.phi_min
+        self.phi_min = 0.0
+        self.phi_max = (self.phi_max - phi_offset) % (2 * np.pi)
+        self.phi_data = (self.phi_data - phi_offset) % (2 * np.pi)
+
+        major_lims = (self.r_min, self.r_max)
+        minor_lims = (self.phi_min, self.phi_max)
+        # Secondary region of interest covers angles on opposite side of origin
+        minor_lims_alt = (self.phi_min + np.pi, self.phi_max + np.pi)
+
+        primary_region = DirectionalAverage(major_data=self.q_data,
+                                            minor_data=self.phi_data,
+                                            major_lims=major_lims,
+                                            minor_lims=minor_lims,
+                                            nbins=self.nbins)
+        secondary_region = DirectionalAverage(major_data=self.q_data,
+                                              minor_data=self.phi_data,
+                                              major_lims=major_lims,
+                                              minor_lims=minor_lims_alt,
+                                              nbins=self.nbins)
+
+        primary_q, primary_I, primary_err = \
+            primary_region(data=self.data, err_data=self.err_data)
+        secondary_q, secondary_I, secondary_err = \
+            secondary_region(data=self.data, err_data=self.err_data)
+
+        if self.fold:
+            # Combining the two regions requires re-binning; the q value
+            # arrays may be unequal lengths, or the indices may correspond to
+            # different q values. To average the results from >2 ROIs you would
+            # need to generalise this process.
+            combined_q = np.zeros(self.nbins)
+            average_intensity = np.zeros(self.nbins)
+            combined_err = np.zeros(self.nbins)
+            bin_counts = np.zeros(self.nbins)
+            for old_index, q_val in enumerate(primary_q):
+                old_index = int(old_index)
+                new_index = primary_region.get_bin_index(q_val)
+                combined_q[new_index] += q_val
+                average_intensity[new_index] += primary_I[old_index]
+                combined_err[new_index] += primary_err[old_index] ** 2
+                bin_counts[new_index] += 1
+            for old_index, q_val in enumerate(secondary_q):
+                old_index = int(old_index)
+                new_index = secondary_region.get_bin_index(q_val)
+                combined_q[new_index] += q_val
+                average_intensity[new_index] += secondary_I[old_index]
+                combined_err[new_index] += secondary_err[old_index] ** 2
+                bin_counts[new_index] += 1
+
+            combined_q /= bin_counts
+            average_intensity /= bin_counts
+            combined_err = np.sqrt(combined_err) / bin_counts
+
+            finite = (np.isfinite(combined_q) & np.isfinite(average_intensity))
+
+            data1d = Data1D(x=combined_q[finite], y=average_intensity[finite],
+                            dy=combined_err[finite])
+        else:
+            combined_q = np.append(np.flip(-1 * secondary_q), primary_q)
+            combined_intensity = np.append(np.flip(secondary_I), primary_I)
+            combined_error = np.append(np.flip(secondary_err), primary_err)
+            data1d = Data1D(x=combined_q, y=combined_intensity,
+                            dy=combined_error)
+
+        return data1d
+
+
+class SectorPhi(PolarROI):
+    """
+    Sector average as a function of phi.
+    I(phi) is return and the data is averaged over Q.
+
+    A sector is defined by r_min, r_max, phi_min, phi_max.
+    The number of bin in phi also has to be defined.
+    """
+
+    def __init__(self, r_min: float, r_max: float, phi_min: float,
+                 phi_max: float, nbins: int = 100) -> None:
+        """
+        TODO - add docstring
+        """
+        super().__init__(r_min=r_min, r_max=r_max,
+                         phi_min=phi_min, phi_max=phi_max)
+        self.nbins = nbins
+
+    def __call__(self, data2d: Data2D = None) -> Data1D:
+        """
+        TODO - add docstring
+        """
+        self.validate_and_assign_data(data2d)
+
+        # Transform all angles to the range [0,2π), where phi_min is at zero.
+        # Remember to transform back afterwards
+        phi_offset = self.phi_min
+        self.phi_min = 0.0
+        self.phi_max = (self.phi_max - phi_offset) % (2 * np.pi)
+        self.phi_data = (self.phi_data - phi_offset) % (2 * np.pi)
+
+        # Averaging takes place between angular and radial limits
+        # When phi_max and phi_min have the same angle, ROI is a full circle.
+        if self.phi_max == 0:
+            major_lims = None
+        else:
+            major_lims = (self.phi_min, self.phi_max)
+        minor_lims = (self.r_min, self.r_max)
+
+        directional_average = DirectionalAverage(major_data=self.phi_data,
+                                                 minor_data=self.q_data,
+                                                 major_lims=major_lims,
+                                                 minor_lims=minor_lims,
+                                                 nbins=self.nbins)
+        phi_data, intensity, error = \
+            directional_average(data=self.data, err_data=self.err_data)
+
+        # Convert angular data back to the original phi range
+        phi_data += phi_offset
+        # In the old manipulations.py, we also had this shift to plot the data
+        # at the centre of the bins. I'm not sure why it's only angular binning
+        # which gets this treatment.
+        phi_data += directional_average.bin_width / 2
+
+        return Data1D(x=phi_data, y=intensity, dy=error)
 

--- a/sasdata/data_util/new_manipulations.py
+++ b/sasdata/data_util/new_manipulations.py
@@ -1,0 +1,324 @@
+import numpy as np
+from abc import ABC, abstractmethod
+from typing import Union
+
+from sasdata.dataloader.data_info import Data1D, Data2D
+
+
+class Binning:
+    """
+    """
+
+    def __init__(self, min_value, max_value, nbins, base=None):
+        """
+        """
+        self.minimum = min_value
+        self.maximum = max_value
+        self.nbins = nbins
+        self.base = base
+
+    def get_index(self, value):
+        """
+        """
+        if self.base:
+            numerator = (np.log(value) - np.log(self.minimum)) \
+                / np.log(self.base)
+            denominator = (np.log(self.maximum) - np.log(self.minimum)) \
+                / np.log(self.base)
+        else:
+            numerator = value - self.minimum
+            denominator = self.maximum - self.minimum
+
+        bin_index = int(np.floor(self.nbins * numerator / denominator))
+
+        # Bins are indexed from 0 to nbins-1, so this check protects against
+        # out-of-range indices when value == maximum.
+        if bin_index == self.nbins:
+            bin_index -= 1
+
+        return bin_index
+
+
+class CartesianROI(ABC):
+    """
+    Base class for manipulators with a rectangular region of interest.
+    """
+
+    def __init__(self, qx_min: float = 0, qx_max: float = 0,
+                 qy_min: float = 0, qy_max: float = 0) -> None:
+        """
+        Placeholder
+        """
+
+        # Units A^-1
+        self.qx_min = qx_min
+        self.qx_max = qx_max
+        self.qy_min = qy_min
+        self.qy_max = qy_max
+
+        # Define data related variables
+        self.data = None
+        self.err_data = None
+        self.qx_data = None
+        self.qy_data = None
+        self.mask_data = None
+
+    @abstractmethod
+    def __call__(self, data2d: Data2D = None) -> Union[float, Data1D]:
+        """
+        Placeholder
+        """
+        return
+
+    # This method might be better placed in a parent class
+    def validate_and_assign_data(self, data2d: Data2D = None) -> None:
+        """
+        Check that the data supplied valid and assign data variables.
+        """
+        if not isinstance(data2d, Data2D):
+            msg = "Data supplied must be of type Data2D."
+            raise TypeError(msg)
+        if len(data2d.detector) > 1:
+            msg = f"Invalid number of detectors: {len(data2d.detector)}"
+            raise ValueError(msg)
+
+        finite_data = np.isfinite(data2d.data)
+        self.data = data2d.data[finite_data]
+        self.err_data = data2d.err_data[finite_data]
+        self.qx_data = data2d.qx_data[finite_data]
+        self.qy_data = data2d.qy_data[finite_data]
+        self.mask_data = data2d.mask[finite_data]
+
+    @property
+    def roi_mask(self):
+        """
+        Return a boolean array listing the elements of self.data which are
+        inside the ROI. This property should only be accessed after
+        CartesianROI has been called.
+        """
+        if any(data is None for data in [self.qx_data, self.qy_data,
+                                         self.mask_data]):
+            raise RuntimeError
+
+        within_x_lims = (self.qx_data >= self.qx_min) & \
+                        (self.qx_data <= self.qx_max)
+        within_y_lims = (self.qy_data >= self.qy_min) & \
+                        (self.qy_data <= self.qy_max)
+
+        # Don't return masked-off data
+        return within_x_lims & within_y_lims & self.mask_data
+
+
+class PolarROI(ABC):
+    """
+    Base class for manipulators whose ROI is defined with polar coordinates.
+    """
+
+    def __init__(self, r_min: float = 0, r_max: float = 1000,
+                 phi_min: float = 0, phi_max: float = 2*np.pi) -> None:
+        """
+        Placeholder
+        """
+
+        # Units A^-1 for radii, radians for angles
+        self.r_min = r_min
+        self.r_max = r_max
+        self.phi_min = phi_min
+        self.phi_max = phi_max
+
+        # Define data related variables
+        self.data = None
+        self.err_data = None
+        self.q_data = None
+        self.qx_data = None
+        self.qy_data = None
+        self.mask_data = None
+
+    @abstractmethod
+    def __call__(self, data2d: Data2D = None) -> Union[float, Data1D]:
+        """
+        Placeholder
+        """
+        return
+
+    # This method might be better placed in a parent class
+    def validate_and_assign_data(self, data2d: Data2D = None) -> None:
+        """
+        Check that the data supplied valid and assign data variables.
+        """
+        if not isinstance(data2d, Data2D):
+            msg = "Data supplied must be of type Data2D."
+            raise TypeError(msg)
+        if len(data2d.detector) > 1:
+            msg = f"Invalid number of detectors: {len(data2d.detector)}"
+            raise ValueError(msg)
+
+        finite_data = np.isfinite(data2d.data)
+        self.data = data2d.data[finite_data]
+        self.err_data = data2d.err_data[finite_data]
+        self.q_data = data2d.q_data[finite_data]
+        self.qx_data = data2d.qx_data[finite_data]
+        self.qy_data = data2d.qy_data[finite_data]
+        self.mask_data = data2d.mask[finite_data]
+
+
+class Boxsum(CartesianROI):
+    """
+    Perform the sum of counts in a 2D region of interest.
+    """
+
+    def __init__(self, qx_min: float = 0, qx_max: float = 0,
+                 qy_min: float = 0, qy_max: float = 0) -> None:
+        super().__init__(qx_min=qx_min, qx_max=qx_max,
+                         qy_min=qy_min, qy_max=qy_max)
+
+    def __call__(self, data2d: Data2D = None) -> float:
+        """
+        Placeholder
+        """
+        self.validate_and_assign_data(data2d)
+        total_sum, error, count = self._sum()
+
+        return total_sum, error, count
+
+    def _sum(self) -> float:
+        """
+        Placeholder
+        """
+
+        # Currently the weights are binary, but could be fractional in future
+        weights = self.roi_mask.astype(int)
+
+        data = weights * self.data
+        err_squared = weights * weights * self.err_data * self.err_data
+        # No points should have zero error, if they do then assume the worst
+        err_squared[self.err_data == 0] = (weights * data)[self.err_data == 0]
+
+        total_sum = np.sum(data)
+        total_count = np.sum(weights)
+        total_errors_squared = np.sum(err_squared)
+
+        return total_sum, np.sqrt(total_errors_squared), total_count
+
+
+class Boxavg(Boxsum):
+    """
+    Perform the average of counts in a 2D region of interest.
+    """
+
+    def __init__(self, qx_min: float = 0, qx_max: float = 0,
+                 qy_min: float = 0, qy_max: float = 0) -> None:
+        super().__init__(qx_min=qx_min, qx_max=qx_max,
+                         qy_min=qy_min, qy_max=qy_max)
+
+    def __call__(self, data2d: Data2D) -> float:
+        """
+        Placeholder
+        """
+        self.validate_and_assign_data(data2d)
+        total_sum, error, count = super()._sum()
+
+        return (total_sum / count), (error / count)
+
+
+class _Slab(CartesianROI):
+    """
+    Compute average I(Q) for a region of interest
+    """
+
+    def __init__(self, qx_min: float = 0, qx_max: float = 0, qy_min: float = 0,
+                 qy_max: float = 0, nbins: int = 100, fold: bool = False):
+        super().__init__(qx_min=qx_min, qx_max=qx_max,
+                         qy_min=qy_min, qy_max=qy_max)
+        self.nbins = nbins
+        self.fold = fold
+
+    def __call__(self, data2d: Data2D = None) -> Data1D:
+        pass
+
+    def _avg(self, data2d: Data2D, major_axis: str) -> Data1D:
+        """
+        Placeholder
+        """
+        self.validate_and_assign_data(data2d)
+
+        # TODO - change weights
+        weights = self.roi_mask.astype(int)
+
+        if major_axis == 'x':
+            q_major = self.qx_data
+            binning = Binning(min_value=0 if self.fold else self.qx_min,
+                              max_value=self.qx_max, nbins=self.nbins)
+        elif major_axis == 'y':
+            q_major = self.qy_data
+            binning = Binning(min_value=0 if self.fold else self.qy_min,
+                              max_value=self.qy_max, nbins=self.nbins)
+        else:
+            msg = f"Unrecognised axis: {major_axis}"
+            raise ValueError(msg)
+
+        q_values = np.zeros(self.nbins)
+        intensity = np.zeros(self.nbins)
+        errs_squared = np.zeros(self.nbins)
+        bin_counts = np.zeros(self.nbins)
+
+        for index, q_value in enumerate(q_major):
+            # Skip over datapoints with no relevance
+            # This should include masked datapoints.
+            if weights[index] == 0:
+                continue
+
+            if self.fold and q_value < 0:
+                q_value = -q_value
+
+            q_bin = binning.get_index(q_value)
+            q_values[q_bin] += weights[index] * q_value
+            intensity[q_bin] += weights[index] * self.data[index]
+            errs_squared[q_bin] += (weights[index] * self.err_data[index]) ** 2
+            # No points should have zero error, assume the worst if they do
+            if self.err_data[index] == 0.0:
+                errs_squared[q_bin] += weights[index] ** 2 * abs(self.data[index])
+            else:
+                errs_squared[q_bin] += (weights[index] * self.err_data[index]) ** 2
+            bin_counts[q_bin] += weights[index]
+
+        errors = np.sqrt(errs_squared)
+        q_values /= bin_counts
+        intensity /= bin_counts
+        errors /= bin_counts
+
+        finite = (np.isfinite(q_values) & np.isfinite(intensity))
+        if not finite.any():
+            msg = "Average Error: No points inside ROI to average..."
+            raise ValueError(msg)
+
+        return Data1D(x=q_values[finite], y=intensity[finite], dy=errors[finite])
+
+
+class SlabX(_Slab):
+    """
+    Compute average I(Qx) for a region of interest
+    """
+
+    def __call__(self, data2d: Data2D = None) -> Data1D:
+        """
+        Compute average I(Qx) for a region of interest
+        :param data2d: Data2D object
+        :return: Data1D object
+        """
+        return self._avg(data2d, 'x')
+
+
+class SlabY(_Slab):
+    """
+    Compute average I(Qy) for a region of interest
+    """
+
+    def __call__(self, data2d: Data2D = None) -> Data1D:
+        """
+        Compute average I(Qy) for a region of interest
+        :param data2d: Data2D object
+        :return: Data1D object
+        """
+        return self._avg(data2d, 'y')
+

--- a/sasdata/data_util/new_manipulations.py
+++ b/sasdata/data_util/new_manipulations.py
@@ -27,9 +27,9 @@ def weights_for_interval(array, l_bound, u_bound, interval_type='half-open'):
     # Half-open is used when binning the major axis (except for the final bin)
     # and closed used for the minor axis and the final bin of the major axis.
     if interval_type == 'half-open':
-        in_range = (l_bound <= array) & (array < u_bound)
+        in_range = np.logical_and(l_bound <= array, array < u_bound)
     elif interval_type == 'closed':
-        in_range = (l_bound <= array) & (array <= u_bound)
+        in_range = np.logical_and(l_bound <= array, array <= u_bound)
     else:
         msg = f"Unrecognised interval_type: {interval_type}"
         raise ValueError(msg)
@@ -127,7 +127,7 @@ class DirectionalAverage:
         denominator = self.major_lims[1] - self.major_lims[0]
         bin_index = int(np.floor(self.nbins * numerator / denominator))
 
-        # Bins are indexed from 0 to nbins-1, so tihs check protects against
+        # Bins are indexed from 0 to nbins-1, so this check protects against
         # out-of-range indices when value == self.major_lims[1]
         if bin_index == self.nbins:
             bin_index -= 1

--- a/sasdata/data_util/new_manipulations.py
+++ b/sasdata/data_util/new_manipulations.py
@@ -180,7 +180,7 @@ class DirectionalAverage:
         intensity /= bin_counts
         errors /= bin_counts
 
-        finite = (np.isfinite(x_axis_values) & np.isfinite(intensity))
+        finite = np.isfinite(intensity)
         if not finite.any():
             msg = "Average Error: No points inside ROI to average..."
             raise ValueError(msg)
@@ -731,7 +731,7 @@ class SectorQ(PolarROI):
             average_intensity /= bin_counts
             combined_err = np.sqrt(combined_err) / bin_counts
 
-            finite = (np.isfinite(combined_q) & np.isfinite(average_intensity))
+            finite = np.isfinite(average_intensity)
 
             data1d = Data1D(x=combined_q[finite], y=average_intensity[finite],
                             dy=combined_err[finite])

--- a/test/sasdataloader/utest_averaging_analytical.py
+++ b/test/sasdataloader/utest_averaging_analytical.py
@@ -1,0 +1,891 @@
+"""
+This file contains unit tests for the various averagers found in
+sasdata/data_util/manipulations.py - These tests are based on analytical
+formulae rather than imported data files.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+from scipy import integrate
+
+from sasdata.dataloader import data_info
+from sasdata.data_util.manipulations import (_Slab, SlabX, SlabY, Boxsum,
+                                             Boxavg, CircularAverage, Ring,
+                                             _Sector, SectorQ, SectorPhi)
+
+
+class MatrixToData2D:
+    """
+    Create Data2D objects from supplied 2D arrays of data.
+    Error data can also be included.
+
+    Adapted from sasdata.data_util.manipulations.reader_2D_converter
+    """
+
+    def __init__(self, data2d=None, err_data=None):
+        if data2d is None:
+            msg = "Data must be supplied to convert to Data2D"
+            raise ValueError(msg)
+        else:
+            matrix = np.asarray(data2d)
+
+        if matrix.ndim != 2:
+            msg = "Supplied array must have 2 dimensions to convert to Data2D"
+            raise ValueError(msg)
+
+        if err_data is not None:
+            err_data = np.asarray(err_data)
+            if err_data.shape != matrix.shape:
+                msg = "Data and errors must have the same shape"
+                raise ValueError(msg)
+
+        # qmax can be any number, 1 just makes things simple.
+        self.qmax = 1
+        qx_bins = np.linspace(start=-1 * self.qmax,
+                              stop=self.qmax,
+                              num=matrix.shape[1],
+                              endpoint=True)
+        qy_bins = np.linspace(start=-1 * self.qmax,
+                              stop=self.qmax,
+                              num=matrix.shape[0],
+                              endpoint=True)
+
+        # Creating arrays in Data2D's preferred format.
+        data2d = matrix.flatten()
+        if err_data is None or np.any(err_data <= 0):
+            # Error data of some kind is needed, so we fabricate some
+            err_data = np.sqrt(np.abs(data2d))  # TODO - use different approach
+        else:
+            err_data = err_data.flatten()
+        qx_data = np.tile(qx_bins, (len(qy_bins), 1)).flatten()
+        qy_data = np.tile(qy_bins, (len(qx_bins), 1)).swapaxes(0, 1).flatten()
+        q_data = np.sqrt(qx_data * qx_data + qy_data * qy_data)
+        mask = np.ones(len(data2d), dtype=bool)
+
+        # Creating a Data2D object to use for testing the averagers.
+        self.data = data_info.Data2D(data=data2d, err_data=err_data,
+                                     qx_data=qx_data, qy_data=qy_data,
+                                     q_data=q_data, mask=mask)
+
+
+class CircularTestingMatrix:
+    """
+    This class is used to generate a 2D array representing a function in polar
+    coordinates. The function, f(r, φ) = R(r) * Φ(φ), factorises into simple
+    radial and angular parts. This makes it easy to determine the form of the
+    function after one of the parts has been averaged over, and therefore good
+    for testing the directional averagers in manipulations.py.
+    This testing is done by comparing the area under the functions, as these
+    will only match if the limits defining the ROI were applied correctly.
+
+    f(r, φ) = R(r) * Φ(φ)
+    R(r) = r ; where 0 <= r <= 1.
+    Φ(φ) = 1 + sin(ν * φ) ; where ν is the frequency and 0 <= φ <= 2π.
+    """
+
+    def __init__(self, frequency=1, matrix_size=201, major_axis=None):
+        """
+        :param frequency: No. times Φ(φ) oscillates over the 0 <= φ <= 2π range
+                          This parameter is largely arbitrary.
+        :param matrix_size: The len() of the output matrix.
+                            Note that odd numbers give a centrepoint of 0,0.
+        :param major_axis: 'Q' or 'Phi' - the axis plotted against by the
+                           averager being tested.
+        """
+        if major_axis not in ('Q', 'Phi'):
+            msg = "Major axis must be either 'Q' or 'Phi'."
+            raise ValueError(msg)
+
+        self.freq = frequency
+        self.matrix_size = matrix_size
+        self.major = major_axis
+
+        # Grid with same dimensions as data matrix, ranging from -1 to 1
+        x, y = np.meshgrid(np.linspace(-1, 1, self.matrix_size),
+                           np.linspace(-1, 1, self.matrix_size))
+        # radius is 0 at the centre, and 1 at (0, +/-1) and (+/-1, 0)
+        radius = np.sqrt(x**2 + y**2)
+        angle = np.arctan2(y, x)
+        # Create the 2D array of data
+        # The sinusoidal part is shifted up by 1 so its average is never 0
+        self.matrix = radius * (1 + np.sin(self.freq * angle))
+
+    def area_under_region(self, r_min=0, r_max=1, phi_min=0, phi_max=2*np.pi):
+        """
+        Integral of the testing matrix along the major axis, between the limits
+        specified. This can be compared to the integral under the 1D data
+        output by the averager being tested to confirm it's working properly.
+
+        :param r_min: value defining the minimum Q in the ROI.
+        :param r_max: value defining the maximum Q in the ROI.
+        :param phi_min: value defining the minimum Phi in the ROI.
+        :param phi_max: value defining the maximum Phi in the ROI.
+        """
+
+        phi_range = phi_max - phi_min
+        # ∫(1 + sin(ν * φ)) dφ = φ + (-cos(ν * φ) / ν) + constant.
+        sine_part_integ = phi_range - (np.cos(self.freq * phi_max) -
+                                       np.cos(self.freq * phi_min)) / self.freq
+        sine_part_avg = sine_part_integ / phi_range
+
+        # ∫(r) dr = r²/2 + constant.
+        linear_part_integ = (r_max ** 2 - r_min ** 2) / 2
+        # The average radius is weighted towards higher radii. The probability
+        # of a point having a given radius value is proportional to the radius:
+        # P(r) = k * r ; where k is some proportionality constant.
+        # ∫[r₀, r₁] P(r) dr = 1, which can be solved for k. This can then be
+        # substituted into ⟨r⟩ = ∫[r₀, r₁] P(r) * r dr, giving:
+        linear_part_avg = 2/3 * (r_max**3 - r_min**3) / (r_max**2 - r_min**2)
+
+        # The integral along the major axis is modulated by the average value
+        # along the minor axis (between the limits).
+        if self.major == 'Q':
+            calculated_area = sine_part_avg * linear_part_integ
+        else:
+            calculated_area = linear_part_avg * sine_part_integ
+
+        return calculated_area
+
+
+class SlabTests(unittest.TestCase):
+    """
+    This class contains all the unit tests for the _Slab class from
+    manipulations.py
+    """
+
+    def test_slab_init(self):
+        """
+        Test that _Slab's __init__ method does what it's supposed to.
+        """
+        x_min = 1
+        x_max = 2
+        y_min = 3
+        y_max = 4
+        bin_width = 0.1
+        fold = True
+
+        slab_object = _Slab(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max,
+                            bin_width=bin_width, fold=fold)
+
+        self.assertEqual(slab_object.x_min, x_min)
+        self.assertEqual(slab_object.x_max, x_max)
+        self.assertEqual(slab_object.y_min, y_min)
+        self.assertEqual(slab_object.y_max, y_max)
+        self.assertEqual(slab_object.bin_width, bin_width)
+        self.assertEqual(slab_object.fold, fold)
+
+    def test_slab_multiple_detectors(self):
+        """
+        Test that _Slab raises an error when there are multiple detectors
+        """
+        averager_data = MatrixToData2D(np.ones([100, 100]))
+        detector1 = data_info.Detector()
+        detector2 = data_info.Detector()
+        averager_data.data.detector.append(detector1)
+        averager_data.data.detector.append(detector2)
+
+        slab_object = _Slab()
+        self.assertRaises(RuntimeError, slab_object._avg, averager_data.data, 'x')
+
+    def test_slab_unknown_axis(self):
+        """
+        Test that _Slab raises an error when given an invalid major axis
+        """
+        averager_data = MatrixToData2D(np.ones([100, 100]))
+        major = 'neither_x_nor_y'
+
+        slab_object = _Slab()
+        self.assertRaises(RuntimeError, slab_object._avg, averager_data.data, major)
+
+    def test_slab_no_points_to_average(self):
+        """
+        Test _Slab raises ValueError when the ROI contains no data
+        """
+        test_data = np.ones([100, 100])
+        averager_data = MatrixToData2D(data2d=test_data)
+
+        # Default params for _Slab are all zeros. Effectively, there is no ROI.
+        slab_object = _Slab()
+        self.assertRaises(ValueError, slab_object._avg, averager_data.data, 'x')
+
+    def test_slab_averaging_x_without_fold(self):
+        """
+        Test that _Slab can average correctly when x is the major axis
+        """
+        matrix_size = 201
+        x, y = np.meshgrid(np.linspace(-1, 1, matrix_size),
+                           np.linspace(-1, 1, matrix_size))
+        # Create a distribution which is quadratic in x and linear in y
+        test_data = x**2 * y
+        averager_data = MatrixToData2D(data2d=test_data)
+
+        # Set up region of interest to average over - the limits are arbitrary.
+        x_min = -0.5 * averager_data.qmax  # = -0.5
+        x_max = averager_data.qmax  # = 1
+        y_min = -0.5 * averager_data.qmax  # = -0.5
+        y_max = averager_data.qmax  # = 1
+        bin_width = (x_max - x_min) / matrix_size
+        # Explicitly not using fold in this test
+        fold = False
+
+        slab_object = _Slab(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max,
+                            bin_width=bin_width, fold=fold)
+        data1d = slab_object._avg(averager_data.data, maj='x')
+
+        # ∫x² dx = x³ / 3 + constant.
+        x_part_integ = (x_max**3 - x_min**3) / 3
+        # ∫y dy = y² / 2 + constant.
+        y_part_integ = (y_max**2 - y_min**2) / 2
+        y_part_avg = y_part_integ / (y_max - y_min)
+        expected_area = y_part_avg * x_part_integ
+        actual_area = integrate.simpson(data1d.y, data1d.x)
+
+        self.assertAlmostEqual(actual_area, expected_area, 2)
+
+        # TODO - also check the errors are being calculated correctly
+
+    def test_slab_averaging_y_without_fold(self):
+        """
+        Test that _Slab can average correctly when y is the major axis
+        """
+        matrix_size = 201
+        x, y = np.meshgrid(np.linspace(-1, 1, matrix_size),
+                           np.linspace(-1, 1, matrix_size))
+        # Create a distribution which is linear in x and quadratic in y
+        test_data = x * y**2
+        averager_data = MatrixToData2D(data2d=test_data)
+
+        # Set up region of interest to average over - the limits are arbitrary.
+        x_min = -0.5 * averager_data.qmax  # = -0.5
+        x_max = averager_data.qmax  # = 1
+        y_min = -0.5 * averager_data.qmax  # = -0.5
+        y_max = averager_data.qmax  # = 1
+        bin_width = (y_max - y_min) / matrix_size
+        # Explicitly not using fold in this test
+        fold = False
+
+        slab_object = _Slab(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max,
+                            bin_width=bin_width, fold=fold)
+        data1d = slab_object._avg(averager_data.data, maj='y')
+
+        # ∫x dx = x² / 2 + constant.
+        x_part_integ = (x_max**2 - x_min**2) / 2
+        x_part_avg = x_part_integ / (x_max - x_min)  # or (x_min + x_max) / 2
+        # ∫y² dy = y³ / 3 + constant.
+        y_part_integ = (y_max**3 - y_min**3) / 3
+        expected_area = x_part_avg * y_part_integ
+        actual_area = integrate.simpson(data1d.y, data1d.x)
+
+        self.assertAlmostEqual(actual_area, expected_area, 2)
+
+        # TODO - also check the errors are being calculated correctly
+
+    def test_slab_averaging_x_with_fold(self):
+        """
+        Test that _Slab can average correctly when x is the major axis
+        """
+        matrix_size = 201
+        x, y = np.meshgrid(np.linspace(-1, 1, matrix_size),
+                           np.linspace(-1, 1, matrix_size))
+        # Create a distribution which is quadratic in x and linear in y
+        test_data = x**2 * y
+        averager_data = MatrixToData2D(data2d=test_data)
+
+        # Set up region of interest to average over - the limits are arbitrary.
+        x_min = -0.5 * averager_data.qmax  # = -0.5
+        x_max = averager_data.qmax  # = 1
+        y_min = -0.5 * averager_data.qmax  # = -0.5
+        y_max = averager_data.qmax  # = 1
+        bin_width = (x_max - x_min) / matrix_size
+        # Explicitly using fold in this test
+        fold = True
+
+        slab_object = _Slab(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max,
+                            bin_width=bin_width, fold=fold)
+        data1d = slab_object._avg(averager_data.data, maj='x')
+
+        # Negative values of x are not graphed when fold = True
+        x_min = 0
+        # ∫x² dx = x³ / 3 + constant.
+        x_part_integ = (x_max**3 - x_min**3) / 3
+        # ∫y dy = y² / 2 + constant.
+        y_part_integ = (y_max**2 - y_min**2) / 2
+        y_part_avg = y_part_integ / (y_max - y_min)
+        expected_area = y_part_avg * x_part_integ
+        actual_area = integrate.simpson(data1d.y, data1d.x)
+
+        self.assertAlmostEqual(actual_area, expected_area, 2)
+
+        # TODO - also check the errors are being calculated correctly
+
+    def test_slab_averaging_y_with_fold(self):
+        """
+        Test that _Slab can average correctly when y is the major axis
+        """
+        matrix_size = 201
+        x, y = np.meshgrid(np.linspace(-1, 1, matrix_size),
+                           np.linspace(-1, 1, matrix_size))
+        # Create a distribution which is linear in x and quadratic in y
+        test_data = x * y**2
+        averager_data = MatrixToData2D(data2d=test_data)
+
+        # Set up region of interest to average over - the limits are arbitrary.
+        x_min = -0.5 * averager_data.qmax  # = -0.5
+        x_max = averager_data.qmax  # = 1
+        y_min = -0.5 * averager_data.qmax  # = -0.5
+        y_max = averager_data.qmax  # = 1
+        bin_width = (y_max - y_min) / matrix_size
+        # Explicitly using fold in this test
+        fold = True
+
+        slab_object = _Slab(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max,
+                            bin_width=bin_width, fold=fold)
+        data1d = slab_object._avg(averager_data.data, maj='y')
+
+        # Negative values of y are not graphed when fold = True, so don't
+        # include them in the area calculation.
+        y_min = 0
+        # ∫x dx = x² / 2 + constant.
+        x_part_integ = (x_max**2 - x_min**2) / 2
+        x_part_avg = x_part_integ / (x_max - x_min)  # or (x_min + x_max) / 2
+        # ∫y² dy = y³ / 3 + constant.
+        y_part_integ = (y_max**3 - y_min**3) / 3
+        expected_area = x_part_avg * y_part_integ
+        actual_area = integrate.simpson(data1d.y, data1d.x)
+
+        self.assertAlmostEqual(actual_area, expected_area, 2)
+
+        # TODO - also check the errors are being calculated correctly
+
+
+class BoxsumTests(unittest.TestCase):
+    """
+    This class contains all the unit tests for the Boxsum class from
+    manipulations.py
+    """
+
+    def test_boxsum_init(self):
+        """
+        Test that Boxsum's __init__ method does what it's supposed to.
+        """
+        x_min = 1
+        x_max = 2
+        y_min = 3
+        y_max = 4
+
+        box_object = Boxsum(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max)
+
+        self.assertEqual(box_object.x_min, x_min)
+        self.assertEqual(box_object.x_max, x_max)
+        self.assertEqual(box_object.y_min, y_min)
+        self.assertEqual(box_object.y_max, y_max)
+
+    def test_boxsum_multiple_detectors(self):
+        """
+        Test Boxsum raises an error when there are multiple detectors.
+        """
+        averager_data = MatrixToData2D(np.ones([100, 100]))
+        detector1 = data_info.Detector()
+        detector2 = data_info.Detector()
+        averager_data.data.detector.append(detector1)
+        averager_data.data.detector.append(detector2)
+
+        box_object = Boxsum()
+        self.assertRaises(RuntimeError, box_object, averager_data.data)
+
+    def test_boxsum_total(self):
+        """
+        Test that Boxsum can find the sum of all of a data set
+        """
+        # Creating a 100x100 matrix for a distribution which is flat in y
+        # and linear in x.
+        test_data = np.tile(np.arange(100), (100, 1))
+        averager_data = MatrixToData2D(data2d=test_data)
+
+        # Selected region is entire data set
+        x_min = -1 * averager_data.qmax
+        x_max = averager_data.qmax
+        y_min = -1 * averager_data.qmax
+        y_max = averager_data.qmax
+        box_object = Boxsum(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max)
+        result, error, npoints = box_object(averager_data.data)
+        correct_sum = np.sum(test_data)
+        # When averager_data was created, we didn't include any error data.
+        # Stand-in error data is created, equal to np.sqrt(data2D).
+        # With the current method of error calculation, this is the result we
+        # should expect. This may need to change at some point.
+        correct_error = np.sqrt(np.sum(test_data))
+
+        self.assertAlmostEqual(result, correct_sum, 6)
+        self.assertAlmostEqual(error, correct_error, 6)
+
+    def test_boxsum_subset_total(self):
+        """
+        Test that Boxsum can find the sum of a portion of a data set
+        """
+        # Creating a 100x100 matrix for a distribution which is flat in y
+        # and linear in x.
+        test_data = np.tile(np.arange(100), (100, 1))
+        averager_data = MatrixToData2D(data2d=test_data)
+
+        # Selection region covers the inner half of the +&- x&y axes
+        x_min = -0.5 * averager_data.qmax
+        x_max = 0.5 * averager_data.qmax
+        y_min = -0.5 * averager_data.qmax
+        y_max = 0.5 * averager_data.qmax
+        # Extracting the inner half of the data set
+        inner_portion = test_data[25:75, 25:75]
+
+        box_object = Boxsum(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max)
+        result, error, npoints = box_object(averager_data.data)
+        correct_sum = np.sum(inner_portion)
+        # When averager_data was created, we didn't include any error data.
+        # Stand-in error data is created, equal to np.sqrt(data2D).
+        # With the current method of error calculation, this is the result we
+        # should expect. This may need to change at some point.
+        correct_error = np.sqrt(np.sum(inner_portion))
+
+        self.assertAlmostEqual(result, correct_sum, 6)
+        self.assertAlmostEqual(error, correct_error, 6)
+
+    def test_boxsum_zero_sum(self):
+        """
+        Test that Boxsum returns 0 when there are no points within the ROI
+        """
+        test_data = np.ones([100, 100])
+        # Make a hole in the middle with zeros
+        test_data[25:75, 25:75] = np.zeros([50, 50])
+        averager_data = MatrixToData2D(data2d=test_data)
+
+        # Selection region covers the inner half of the +&- x&y axes
+        x_min = -0.5 * averager_data.qmax
+        x_max = 0.5 * averager_data.qmax
+        y_min = -0.5 * averager_data.qmax
+        y_max = 0.5 * averager_data.qmax
+        box_object = Boxsum(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max)
+        result, error, npoints = box_object(averager_data.data)
+
+        self.assertAlmostEqual(result, 0, 6)
+        self.assertAlmostEqual(error, 0, 6)
+
+
+class BoxavgTests(unittest.TestCase):
+    """
+    This class contains all the unit tests for the Boxavg class from
+    manipulations.py
+    """
+
+    def test_boxavg_init(self):
+        """
+        Test that Boxavg's __init__ method does what it's supposed to.
+        """
+        x_min = 1
+        x_max = 2
+        y_min = 3
+        y_max = 4
+
+        box_object = Boxavg(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max)
+
+        self.assertEqual(box_object.x_min, x_min)
+        self.assertEqual(box_object.x_max, x_max)
+        self.assertEqual(box_object.y_min, y_min)
+        self.assertEqual(box_object.y_max, y_max)
+
+    def test_boxavg_multiple_detectors(self):
+        """
+        Test Boxavg raises an error when there are multiple detectors.
+        """
+        averager_data = MatrixToData2D(np.ones([100, 100]))
+        detector1 = data_info.Detector()
+        detector2 = data_info.Detector()
+        averager_data.data.detector.append(detector1)
+        averager_data.data.detector.append(detector2)
+
+        box_object = Boxavg()
+        self.assertRaises(RuntimeError, box_object, averager_data.data)
+
+    def test_boxavg_total(self):
+        """
+        Test that Boxavg can find the average of all of a data set
+        """
+        # Creating a 100x100 matrix for a distribution which is flat in y
+        # and linear in x.
+        test_data = np.tile(np.arange(100), (100, 1))
+        averager_data = MatrixToData2D(data2d=test_data)
+
+        # Selected region is entire data set
+        x_min = -1 * averager_data.qmax
+        x_max = averager_data.qmax
+        y_min = -1 * averager_data.qmax
+        y_max = averager_data.qmax
+        box_object = Boxavg(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max)
+        result, error = box_object(averager_data.data)
+        correct_avg = np.mean(test_data)
+        # When averager_data was created, we didn't include any error data.
+        # Stand-in error data is created, equal to np.sqrt(data2D).
+        # With the current method of error calculation, this is the result we
+        # should expect. This may need to change at some point.
+        correct_error = np.sqrt(np.sum(test_data)) / test_data.size
+
+        self.assertAlmostEqual(result, correct_avg, 6)
+        self.assertAlmostEqual(error, correct_error, 6)
+
+    def test_boxavg_subset_total(self):
+        """
+        Test that Boxavg can find the average of a portion of a data set
+        """
+        # Creating a 100x100 matrix for a distribution which is flat in y
+        # and linear in x.
+        test_data = np.tile(np.arange(100), (100, 1))
+        averager_data = MatrixToData2D(data2d=test_data)
+
+        # Selection region covers the inner half of the +&- x&y axes
+        x_min = -0.5 * averager_data.qmax
+        x_max = 0.5 * averager_data.qmax
+        y_min = -0.5 * averager_data.qmax
+        y_max = 0.5 * averager_data.qmax
+        # Extracting the inner half of the data set
+        inner_portion = test_data[25:75, 25:75]
+
+        box_object = Boxavg(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max)
+        result, error = box_object(averager_data.data)
+        correct_avg = np.mean(inner_portion)
+        # When averager_data was created, we didn't include any error data.
+        # Stand-in error data is created, equal to np.sqrt(data2D).
+        # With the current method of error calculation, this is the result we
+        # should expect. This may need to change at some point.
+        correct_error = np.sqrt(np.sum(inner_portion)) / inner_portion.size
+
+        self.assertAlmostEqual(result, correct_avg, 6)
+        self.assertAlmostEqual(error, correct_error, 6)
+
+    def test_boxavg_zero_average(self):
+        """
+        Test that Boxavg returns 0 when there are no points within the ROI
+        """
+        test_data = np.ones([100, 100])
+        # Make a hole in the middle with zeros
+        test_data[25:75, 25:75] = np.zeros([50, 50])
+        averager_data = MatrixToData2D(data2d=test_data)
+
+        # Selection region covers the inner half of the +&- x&y axes
+        x_min = -0.5 * averager_data.qmax
+        x_max = 0.5 * averager_data.qmax
+        y_min = -0.5 * averager_data.qmax
+        y_max = 0.5 * averager_data.qmax
+        box_object = Boxavg(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max)
+        result, error = box_object(averager_data.data)
+
+        self.assertAlmostEqual(result, 0, 6)
+        self.assertAlmostEqual(error, 0, 6)
+
+
+class CircularAverageTests(unittest.TestCase):
+    """
+    This class contains all the tests for the CircularAverage class
+    from manipulations.py
+    """
+
+    def test_circularaverage_init(self):
+        """
+        Test that CircularAverage's __init__ method does what it's supposed to.
+        """
+        r_min = 1
+        r_max = 2
+        bin_width = 0.01
+
+        circ_object = CircularAverage(r_min=r_min, r_max=r_max,
+                                      bin_width=bin_width)
+
+        self.assertEqual(circ_object.r_min, r_min)
+        self.assertEqual(circ_object.r_max, r_max)
+        self.assertEqual(circ_object.bin_width, bin_width)
+
+    def test_circularaverage_dq_retrieval(self):
+        """
+        Test that CircularAverage is able to calclate dq_data correctly when
+        the data provided has dqx_data and dqy_data.
+        """
+
+        # I'm saving the implementation of this bit for later
+        pass
+
+    def test_circularaverage_multiple_detectors(self):
+        """
+        Test CircularAverage raises an error when there are multiple detectors
+        """
+
+        # This test can't be implemented yet, because CircularAverage does not
+        # check the number of detectors.
+        # TODO - establish whether CircularAverage should be making this check.
+        pass
+
+    def test_circularaverage_check_q_data(self):
+        """
+        Check CircularAverage ensures the data supplied has `q_data` populated
+        """
+        # test_data = np.ones([100, 100])
+        # averager_data = DataMatrixToData2D(test_data)
+        # # Overwrite q_data so it's empty
+        # averager_data.data.q_data = np.array([])
+        # circ_object = CircularAverage()
+        # self.assertRaises(RuntimeError, circ_object, averager_data.data)
+
+        # This doesn't work. I'll come back to this later too
+        pass
+
+    def test_circularaverage_check_valid_radii(self):
+        """
+        Test that CircularAverage raises ValueError when r_min > r_max
+        """
+        test_data = np.ones([100, 100])
+        averager_data = MatrixToData2D(test_data)
+
+        circ_object = CircularAverage(r_min=0.1, r_max=0.05)
+        self.assertRaises(ValueError, circ_object, averager_data.data)
+
+    def test_circularaverage_no_points_to_average(self):
+        """
+        Test CircularAverage raises ValueError when the ROI contains no data
+        """
+        test_data = np.ones([100, 100])
+        averager_data = MatrixToData2D(test_data)
+
+        # Region of interest well outside region with data
+        circ_object = CircularAverage(r_min=2 * averager_data.qmax,
+                                      r_max=3 * averager_data.qmax)
+        self.assertRaises(ValueError, circ_object, averager_data.data)
+
+    def test_circularaverage_averages_circularly(self):
+        """
+        Test that CircularAverage can calculate a circular average correctly.
+        """
+        test_data = CircularTestingMatrix(frequency=2, major_axis='Q')
+        averager_data = MatrixToData2D(test_data.matrix)
+
+        # Test the ability to average over a subsection of the data
+        r_min = averager_data.qmax * 0.25
+        r_max = averager_data.qmax * 0.75
+
+        circ_object = CircularAverage(r_min=r_min, r_max=r_max)
+        data1d = circ_object(averager_data.data)
+
+        expected_area = test_data.area_under_region(r_min=r_min, r_max=r_max)
+        actual_area = integrate.trapezoid(data1d.y, data1d.x)
+
+        self.assertAlmostEqual(actual_area, expected_area, 3)
+
+        # TODO - also check the errors are being calculated correctly
+
+
+class RingTests(unittest.TestCase):
+    """
+    This class contains the tests for the Ring class from manipulations.py
+    A.K.A AnnulusSlicer on the sasview side
+    """
+
+    def test_ring_init(self):
+        """
+        Test that Ring's __init__ method does what it's supposed to.
+        """
+        r_min = 1
+        r_max = 2
+        nbins = 100
+
+        # Note that Ring also has params center_x and center_y, but these are
+        # not used by the slicers and there is a 'todo' in manipulations.py to
+        # remove them. For this reason, I have not tested their initialisation.
+        ring_object = Ring(r_min=r_min, r_max=r_max, nbins=nbins)
+
+        self.assertEqual(ring_object.r_min, r_min)
+        self.assertEqual(ring_object.r_max, r_max)
+        self.assertEqual(ring_object.nbins_phi, nbins)
+
+    def test_ring_non_plottable_data(self):
+        """
+        Test that RuntimeError is raised if the data supplied isn't plottable
+        """
+        # with patch("sasdata.data_util.manipulations.Ring.data2D.__class__.__name__") as p:
+        #     p.return_value = "bad_name"
+        #     ring_object = Ring()
+        #     self.assertRaises(RuntimeError, ring_object.__call__)
+
+        # I can't seem to get patch working, in this test or in others.
+        pass
+
+    def test_ring_no_points_to_average(self):
+        """
+        Test Ring raises ValueError when the ROI contains no data
+        """
+        test_data = np.ones([100, 100])
+        averager_data = MatrixToData2D(test_data)
+
+        # Region of interest well outside region with data
+        ring_object = Ring(r_min=2 * averager_data.qmax,
+                           r_max=3 * averager_data.qmax)
+        self.assertRaises(ValueError, ring_object, averager_data.data)
+
+    def test_ring_averages_azimuthally(self):
+        """
+        Test that Ring can calculate an azimuthal average correctly.
+        """
+        test_data = CircularTestingMatrix(frequency=1, matrix_size=201,
+                                          major_axis='Phi')
+        averager_data = MatrixToData2D(test_data.matrix)
+
+        # Test the ability to average over a subsection of the data
+        r_min = 0.25 * averager_data.qmax
+        r_max = 0.75 * averager_data.qmax
+        nbins = int(test_data.matrix_size / 2)
+
+        ring_object = Ring(r_min=r_min, r_max=r_max, nbins=nbins)
+        data1d = ring_object(averager_data.data)
+
+        expected_area = test_data.area_under_region(r_min=r_min, r_max=r_max)
+        actual_area = integrate.simpson(data1d.y, data1d.x)
+
+        self.assertAlmostEqual(actual_area, expected_area, 1)
+
+        # TODO - also check the errors are being calculated correctly
+
+
+class SectorTests(unittest.TestCase):
+    """
+    This class contains the tests for the _Sector class from manipulations.py
+    On the sasview side, this includes SectorSlicer and WedgeSlicer.
+
+    The parameters frequency, r_min, r_max, phi_min and phi_max are largely
+    arbitrary, and the tests should pass if any sane value is used for them.
+    """
+
+    def test_sector_init(self):
+        """
+        Test that _Sector's __init__ method does what it's supposed to.
+        """
+        r_min = 1
+        r_max = 2
+        phi_min = 0
+        phi_max = np.pi
+        nbins = 100
+        base = 10
+
+        sector_object = _Sector(r_min=r_min, r_max=r_max, phi_min=phi_min,
+                                phi_max=phi_max, nbins=nbins, base=base)
+
+        self.assertEqual(sector_object.r_min, r_min)
+        self.assertEqual(sector_object.r_max, r_max)
+        self.assertEqual(sector_object.phi_min, phi_min)
+        self.assertEqual(sector_object.phi_max, phi_max)
+        self.assertEqual(sector_object.nbins, nbins)
+        self.assertEqual(sector_object.base, base)
+
+    def test_sector_non_plottable_data(self):
+        """
+        Test that RuntimeError is raised if the data supplied isn't plottable
+        """
+        # Implementing this test can wait
+        pass
+
+    def test_sector_phi_averaging(self):
+        """
+        Test _Sector can average correctly with a major axis of phi, when all
+        of min/max r & phi params are specified and have their expected form.
+        """
+        test_data = CircularTestingMatrix(frequency=1, matrix_size=201,
+                                          major_axis='Phi')
+        averager_data = MatrixToData2D(test_data.matrix)
+
+        r_min = 0.1 * averager_data.qmax
+        r_max = 0.9 * averager_data.qmax
+        phi_min = np.pi/6
+        phi_max = 5*np.pi/6
+        nbins = int(test_data.matrix_size * np.sqrt(2)/4)  # usually reliable
+
+        wedge_object = SectorPhi(r_min=r_min, r_max=r_max, phi_min=phi_min + np.pi,
+                                 phi_max=phi_max + np.pi, nbins=nbins)
+        data1d = wedge_object(averager_data.data)
+
+        expected_area = test_data.area_under_region(r_min=r_min, r_max=r_max,
+                                                    phi_min=phi_min,
+                                                    phi_max=phi_max)
+        actual_area = integrate.simpson(data1d.y, data1d.x)
+
+        self.assertAlmostEqual(actual_area, expected_area, 1)
+
+        # TODO - Something is very wrong with this test
+
+    def test_sector_q_averaging_without_fold(self):
+        """
+        Test _Sector can average correctly w/ major axis q and fold disabled.
+        All min/max r & phi params are specified and have their expected form.
+        """
+        test_data = CircularTestingMatrix(frequency=1, matrix_size=201,
+                                          major_axis='Q')
+        averager_data = MatrixToData2D(test_data.matrix)
+
+        r_min = 0.1 * averager_data.qmax
+        r_max = 0.9 * averager_data.qmax
+        phi_min = np.pi/6
+        phi_max = 5*np.pi/6
+        nbins = int(test_data.matrix_size * np.sqrt(2)/4)  # usually reliable
+
+        wedge_object = SectorQ(r_min=r_min, r_max=r_max, phi_min=phi_min + np.pi,
+                               phi_max=phi_max + np.pi, nbins=nbins)
+        # Explicitly set fold to False - results span full +/- range
+        wedge_object.fold = False
+        data1d = wedge_object(averager_data.data)
+
+        expected_area = test_data.area_under_region(r_min=r_min, r_max=r_max,
+                                                    phi_min=phi_min,
+                                                    phi_max=phi_max)
+        # With fold set to False, the sector on the opposite side of the origin
+        # to the one specified is also graphed as negative Q values. Therefore,
+        # the area of this other half needs to be accounted for.
+        expected_area += test_data.area_under_region(r_min=r_min, r_max=r_max,
+                                                     phi_min=phi_min+np.pi,
+                                                     phi_max=phi_max+np.pi)
+        actual_area = integrate.simpson(data1d.y, data1d.x)
+
+        self.assertAlmostEqual(actual_area, expected_area, 1)
+
+    def test_sector_q_averaging_with_fold(self):
+        """
+        Test _Sector can average correctly w/ major axis q and fold enabled.
+        All min/max r & phi params are specified and have their expected form.
+        """
+        test_data = CircularTestingMatrix(frequency=1, matrix_size=201,
+                                          major_axis='Q')
+        averager_data = MatrixToData2D(test_data.matrix)
+
+        r_min = 0.1 * averager_data.qmax
+        r_max = 0.9 * averager_data.qmax
+        phi_min = np.pi/6
+        phi_max = 5*np.pi/6
+        nbins = int(test_data.matrix_size * np.sqrt(2)/4)  # usually reliable
+
+        wedge_object = SectorQ(r_min=r_min, r_max=r_max,
+                               phi_min=phi_min + np.pi,
+                               phi_max=phi_max + np.pi, nbins=nbins)
+        # Explicitly set fold to True - points either side of 0,0 are averaged
+        wedge_object.fold = True
+        data1d = wedge_object(averager_data.data)
+
+        expected_area = test_data.area_under_region(r_min=r_min, r_max=r_max,
+                                                    phi_min=phi_min,
+                                                    phi_max=phi_max)
+        # With fold set to True, points from the sector on the opposite side of
+        # the origin to the one specified are averaged with points from the
+        # specified sector.
+        expected_area += test_data.area_under_region(r_min=r_min, r_max=r_max,
+                                                     phi_min=phi_min+np.pi,
+                                                     phi_max=phi_max+np.pi)
+        expected_area /= 2
+        actual_area = integrate.simpson(data1d.y, data1d.x)
+
+        self.assertAlmostEqual(actual_area, expected_area, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

This pull request covers the last part of my summer project: the `manipulations.py` rewrite. It also includes the new analytical unit tests, from branch `44-new-unit-tests-for-slicer-averagers`, except in this branch they point towards the new manipulations module instead of the old one.

The details of the `manipulations.py` rewrite are as follows:
* Parent classes for Cartesian and Polar regions of interest setup have now been added, drastically reducing the amount of repeated code.
* The directional averagers (SlabX, Ring, SectorQ, etc) now all use a common `DirectionalAverage` class for the bulk of their computation. This too reduces repeated code and increases maintainability.
* The method of weighting datapoints based on their position relative to the ROI (inside or outside) has been retooled to make it easier to implement fractional binning later down the line.
* All the data manipulators require an `nbins` parameter now, whereas before some needed `bin_width` instead.

The main functionality change is how `DirectionalAverage` considers the weights of the datapoints. In both the new and old `manipulations.py` these weights are either 0 or 1, though now it should be a lot easier to implement fractional weights. Previously, the weight assigned to a datapoint was calculated on-the-fly as part of a for loop which ran over each datapoint and was also responsible for part of the averaging process. The new methodology separates out the weighting and averaging processes, creating an `n`x`m` weights matrix where `n` is the number of bins the data is sorted into, and `m` is the number of datapoints. The averaging is then done using matrix multiplication and numpy functions. This new method will certainly be more memory heavy than the old method, and it could be slower for large datasets. My hope is however that the switch from python functions to numpy functions will mitigate this, and the improvement to the quality of results once fractional weights are added should more than justify the resource usage.

Dependencies needed: scipy - needed for new unit tests.
Note that merging this pull request requires that a sister pull request in the sasview repo also be merged: **LINK_HERE**

Fixes #46 (issue announcing rewrite plan) and fixes #44 (issue about dodgy unit tests) and fixes #43 (wedge averaging had issues with full-circle ROIs).

## How Has This Been Tested?

There are two ways this rewrite has been tested. The less rigorous method involved using this branch plus the sasview branch mentioned above to confirm that the plotted results look the same before and after using the same data file, slicer and slicer parameters. The more rigorous method involves the new unit tests. When the file `utest_averaging_analytical.py` from the branch `44-new-unit-tests-for-slicer-averagers` is run, you see that averagers from the previous version of `manipulations.py` all pass these tests. The version of `utest_averaging_analytical.py` included in this branch tests the new averagers, and these also pass the tests. Note there are other minor changes made to the tests for compatibility with the new averagers.

## Work still to be done

At a superficial level, there are some files which need renaming. The new version of `manipulations.py` goes by the name `new_manipulations.py`. Once everyone is satisfied with this new version, it should be renamed to replace the old one. There are references to `new_manipulations` in `utest_averaging_analytical.py` on the sasdata side, as well as in `Plotter2D.py`, `AnnulusSlicer.py`, `BoxSlicer.py`, `BoxSum.py`, `WedgeSlicer.py`, and `SectorSlicer.py` on the sasview side. These should also be changed accordingly.

There is also some more serious work to do before this rewrite can truly be considered complete. For the most part we've already reached feature parity with the old `manipulations.py`, but there are some blind spots which need acknowledging.

1. In the old version of `manipulations.py`, the `_Sector` class had the option to bin the data logarithmically. As far as I can tell this functionality was never called upon by sasview. There may be users who use it in custom scripts however, so it would still be worth implementing here. As a bonus, the feature would now be available to all slicers.
2. Currently, no attention is paid to the data's resolution function. In the old `manipulations.py`, `CircularAverage` and `_Sector` call a function by the name of `get_dq_data`. I don't quite understand the maths, but I get the impression from Lucas that it doesn't function as it should. The last thing needed to complete this rewrite would be proper consideration of the `dqx_data` and `dqy_data` properties of the supplied Data2D object to compute the `dx` property of the returned Data1D object. The maths involved here is a little outside my comfort zone, so I'd be happy to delegate this responsibility to someone else.
3. I'd like to restructure the unit tests file. At the moment the tests are grouped in classes based on the averager they're testing, but if instead they were grouped by the kind of test being performed I could use unittest's setUp and tearDown methods to reduce the amount of repeated code. They also only test the averagers under expected conditions. Although the old tests were no more rigorous, I think it would be good write some tests for edge cases.

## Review Checklist (please remove items if they don't apply):

- [ ] Code has been reviewed
- [ ] Functionality has been tested
- [ ] Windows installer (GH artifact) has been tested (installed and worked) 
- [ ] MacOSX installer (GH artifact) has been tested (installed and worked) 
- [X] User documentation is available and complete (if required)
- [X] Developers documentation is available and complete (if required)
- [X] The introduced changes comply with SasView license (BSD 3-Clause)