### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "{name}={dir::$(pip cache dir)}" >> $GITHUB_OUTPUT
 
     - name: Obtain pip cache (Linux)
       uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
       fail-fast: false
 
     steps:


### PR DESCRIPTION
This PR removes py3.8 support and adds py3.11. It also removes `set-output` which has been deprecated from GitHub actions.