### PR TITLE
55: Generate Developer Docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,14 +1,17 @@
 # Minimal makefile for Sphinx documentation
-#
 
 # Environment variables
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SPHINXAPIDOC  ?= sphinx-apidoc
 APIOPTS       = -d 8 -H SasData
+DOCSDIR       = docs
 SOURCEDIR     = source
 BUILDDIR      = build
-CD            = cd
+DEVDIR        = dev
+LIBDIR        = lib
+GENDIR        = generated
+UP            = ..
 
 ifdef ComSpec
     RMDIR   = rmdir /s/q
@@ -20,27 +23,31 @@ else
     PATHSEP = $(strip /)
 endif
 
-LIBDIR        = $(BUILDDIR)$(PATHSEP)lib
+SASDATABUILD  = $(UP)$(PATHSEP)$(BUILDDIR)$(PATHSEP)$(LIBDIR)
+DOCSSRC       = $(SOURCEDIR)
+DEV           = $(DOCSSRC)$(PATHSEP)$(DEVDIR)
+DEVGEN        = $(DEV)$(PATHSEP)$(GENDIR)
+DOCSBUILD     = $(DOCSSRC)$(PATHSEP)$(BUILDDIR)
 
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 clean:
-	-$(RMDIR) "$(SOURCEDIR)$(PATHSEP)dev$(PATHSEP)generated/" "$(BUILDDIR)"
+	-$(RMDIR) "$(DEVGEN)" "$(DOCSBUILD)"
 
 dir:
-	-$(MKDIR) "$(BUILDDIR)"
-	-$(MKDIR) "$(LIBDIR)"
+	-$(MKDIR) "$(DEVGEN)"
+	-$(MKDIR) "$(DOCSBUILD)"
 
 .PHONY: help Makefile
 
 # Generate the api docs
 api:
-	$(SPHINXAPIDOC) -o "$(SOURCEDIR)$(PATHSEP)dev$(PATHSEP)generated/" $(APIOPTS) "$(LIBDIR)"
+	$(SPHINXAPIDOC) -o "$(DEVGEN)" $(APIOPTS) "$(SASDATABUILD)"
 
 html: dir api
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(DOCSSRC)" "$(DOCSBUILD)" $(SPHINXOPTS) $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/source/dev/dev.rst
+++ b/docs/source/dev/dev.rst
@@ -6,6 +6,6 @@ Developer Documentation
 =======================
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 8
 
-    SasData <generated/modules>
+    SasData <generated/sasdata>


### PR DESCRIPTION
As noted by @smk78, the developer documentation was not present in the build. This PR corrects that mistake.

To check the docs are bundling with sasview properly, please check the builds in https://github.com/SasView/sasview/actions/runs/7121411183/

Fixes #55