### PR TITLE
57: Restrict lxml to versions less than 5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Data import/export requirements
 h5py
-lxml
+lxml < 5.0
 
 # Calculation
 numpy


### PR DESCRIPTION
This limits the version of the XML reader library, [lxml](https://lxml.de/), to under v5.0. The changes made in v5.0 and beyond seem to break unit tests in MacOS and Ubuntu, but not for Windows for some reason. This is a temporary fix until a proper solution can be investigated.

Refs #57 (NOTE - this should not close the issue)