### PR TITLE
Fix delta in sesans docs

### DIFF
--- a/docs/source/user/data/data_formats_help.rst
+++ b/docs/source/user/data/data_formats_help.rst
@@ -115,7 +115,7 @@ Following the header are up to 8 space-delimited columns of experimental
 variables of which the first 4 columns are required. In order, these are:
 
 - Spin-echo length (:math:`\delta`, in Angstroms)
-- Depolarization (:math:`log(P/P_0)/(lambda^2 * thickness)`, in Angstrom :sup:`-1` cm :sup:`-1`\ )
+- Depolarization (:math:`log(P/P_0)/(\lambda^2 * thickness)`, in Angstrom :sup:`-1` cm :sup:`-1`\ )
 - Depolarization error (also in in Angstrom :sup:`-1` cm :sup:`-1`\ ) (i.e. the measurement error)
 - Spin-echo length error (:math:`\Delta \delta`, in Angstroms) (i.e. the experimental resolution)
 - Neutron wavelength (:math:`\lambda`, in Angstroms)

--- a/sasdata/example_data/media/testdata_help.rst
+++ b/sasdata/example_data/media/testdata_help.rst
@@ -346,15 +346,15 @@ SESANS Test Data
 
 sphere_isis
   - SESANS data from 100nm PMMA latex nanoparticles in h/d-decalin collected on
-    the LARMOR instrument at ISIS over spin-echo lengths 260 < |delta| < 19300 |Ang| .
+    the LARMOR instrument at ISIS over spin-echo lengths 260 < :math:`\delta` < 19300 |Ang| .
 
 spheres2micron
   - SESANS data from 2 micron polystyrene spheres in 53% H2O / 47% D2O collected
-    on the LARMOR instrument at ISIS over spin-echo lengths 400 < |delta| < 46000 |Ang| .
+    on the LARMOR instrument at ISIS over spin-echo lengths 400 < :math:`\delta` < 46000 |Ang| .
 
 spheres2micron_long
   - SESANS data from 2 micron polystyrene spheres in 53% H2O / 47% D2O collected
-    on the LARMOR instrument at ISIS over spin-echo lengths 400 < |delta| < 200000 |Ang| .
+    on the LARMOR instrument at ISIS over spin-echo lengths 400 < |:math:`\delta` < 200000 |Ang| .
 
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 

--- a/sasdata/example_data/media/testdata_help.rst
+++ b/sasdata/example_data/media/testdata_help.rst
@@ -354,7 +354,7 @@ spheres2micron
 
 spheres2micron_long
   - SESANS data from 2 micron polystyrene spheres in 53% H2O / 47% D2O collected
-    on the LARMOR instrument at ISIS over spin-echo lengths 400 < |:math:`\delta` < 200000 |Ang| .
+    on the LARMOR instrument at ISIS over spin-echo lengths 400 < :math:`\delta` < 200000 |Ang| .
 
 .. ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
 


### PR DESCRIPTION
Fixed delta symbols from changes made in PR #60 that were not rendering properly in the docs.