### PR TITLE
Release 0.9.0: Update release notes, version, and copyright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,33 +14,22 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
       fail-fast: false
 
     steps:
 
     - name: Obtain SasData source from git
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
-    ### Caching of pip downloads and local wheel builds
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "name={$(pip cache dir)}" >> $GITHUB_OUTPUT
-
-    - name: Obtain pip cache (Linux)
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.pip-cache.outputs.name }}
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/test.yml') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.python-version }}-
-          ${{ runner.os }}-pip-
+        cache: 'pip'
+        cache-dependency-path: |
+          **/ci.yml
+          **/requirements*.txt
 
     ### Installation of build-dependencies
 

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,5 +1,4 @@
-Copyright (c) 2009-2022, SasView Developers
-
+Copyright (c) 2009-2024, SasView Developers
 
 All rights reserved.
 

--- a/docs/source/user/RELEASE.rst
+++ b/docs/source/user/RELEASE.rst
@@ -14,6 +14,43 @@ Features
 ========
 Wheel, egg, and tar.gz files are available on `pypi <https://pypi.org/project/sasdata/>`_.
 
+New in Version 0.9.0
+--------------------
+This is an enhancement release with updates to the unit conversion routines, the ability to load data from URIs, the
+addition of a wedge slicer and other slicer enhancements.
+
+What's Changed
+^^^^^^^^^^^^^^
+
+Feature Enhancements
+____________________
+* Refactor nxsunit by @krzywon in https://github.com/SasView/sasdata/pull/13
+* Enable the sector slicing to allow both sides independantly by @butlerpd in https://github.com/SasView/sasdata/pull/36
+* 31: Load data from URIs by @krzywon in https://github.com/SasView/sasdata/pull/37
+* SasData counterpart to SasView SlicerExtension_1344 by @jack-rooks in https://github.com/SasView/sasdata/pull/61
+
+Bug Fixes
+_________
+* Fixing Issue #40 (but properly this time) by @ehewins in https://github.com/SasView/sasdata/pull/42
+* changed xaxis label for updated SESANS nomenclature from z to delta by @caitwolf in https://github.com/SasView/sasdata/pull/60
+* Fix delta in sesans docs by @caitwolf in https://github.com/SasView/sasdata/pull/65
+
+Documentation Changes
+_____________________
+* 14: Rework readme by @krzywon in https://github.com/SasView/sasdata/pull/15
+* 29: Building sasdata documentation by @krzywon in https://github.com/SasView/sasdata/pull/53
+* 55: Generate Developer Docs by @krzywon in https://github.com/SasView/sasdata/pull/56
+
+Infrastructure Changes
+______________________
+* Remove entry_point from setup.py by @krzywon in https://github.com/SasView/sasdata/pull/2
+* 32: Dependency cleanup by @krzywon in https://github.com/SasView/sasdata/pull/33
+* 8: Move example data to sasdata by @krzywon in https://github.com/SasView/sasdata/pull/49
+* CI updates by @krzywon in https://github.com/SasView/sasdata/pull/50
+* 57: Restrict lxml to versions less than 5.0 by @krzywon in https://github.com/SasView/sasdata/pull/63
+* Update example data by @smk78 in https://github.com/SasView/sasdata/pull/58
+* 67: Fix broken unit test(s) by @krzywon in https://github.com/SasView/sasdata/pull/68
+
 New in Version 0.8.1
 --------------------
 This is a point release to fix a build issue. The `sasdata.data_utils` package was omitted from setup.py causing an

--- a/docs/source/user/RELEASE.rst
+++ b/docs/source/user/RELEASE.rst
@@ -26,7 +26,7 @@ Feature Enhancements
 ____________________
 * Refactor nxsunit by @krzywon in https://github.com/SasView/sasdata/pull/13
 * Enable the sector slicing to allow both sides independantly by @butlerpd in https://github.com/SasView/sasdata/pull/36
-* 31: Load data from URIs by @krzywon in https://github.com/SasView/sasdata/pull/37
+* Load data from URIs by @krzywon in https://github.com/SasView/sasdata/pull/37
 * SasData counterpart to SasView SlicerExtension_1344 by @jack-rooks in https://github.com/SasView/sasdata/pull/61
 
 Bug Fixes
@@ -37,19 +37,19 @@ _________
 
 Documentation Changes
 _____________________
-* 14: Rework readme by @krzywon in https://github.com/SasView/sasdata/pull/15
-* 29: Building sasdata documentation by @krzywon in https://github.com/SasView/sasdata/pull/53
-* 55: Generate Developer Docs by @krzywon in https://github.com/SasView/sasdata/pull/56
+* Rework readme by @krzywon in https://github.com/SasView/sasdata/pull/15
+* Building sasdata documentation by @krzywon in https://github.com/SasView/sasdata/pull/53
+* Generate Developer Docs by @krzywon in https://github.com/SasView/sasdata/pull/56
 
 Infrastructure Changes
 ______________________
 * Remove entry_point from setup.py by @krzywon in https://github.com/SasView/sasdata/pull/2
-* 32: Dependency cleanup by @krzywon in https://github.com/SasView/sasdata/pull/33
-* 8: Move example data to sasdata by @krzywon in https://github.com/SasView/sasdata/pull/49
+* Dependency cleanup by @krzywon in https://github.com/SasView/sasdata/pull/33
+* Move example data to sasdata by @krzywon in https://github.com/SasView/sasdata/pull/49
 * CI updates by @krzywon in https://github.com/SasView/sasdata/pull/50
-* 57: Restrict lxml to versions less than 5.0 by @krzywon in https://github.com/SasView/sasdata/pull/63
+* Restrict lxml to versions less than 5.0 by @krzywon in https://github.com/SasView/sasdata/pull/63
 * Update example data by @smk78 in https://github.com/SasView/sasdata/pull/58
-* 67: Fix broken unit test(s) by @krzywon in https://github.com/SasView/sasdata/pull/68
+* Fix broken unit test(s) by @krzywon in https://github.com/SasView/sasdata/pull/68
 
 New in Version 0.8.1
 --------------------

--- a/sasdata/__init__.py
+++ b/sasdata/__init__.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 
 # An importable path to the example data to
 data_path: Path = Path(os.path.join(Path(os.path.dirname(__file__)), 'example_data'))


### PR DESCRIPTION
This updates the version, and copyright. I still need to finalize the release notes document.

This also updates the actions to remove py3.9 support and moves actions to their latest, still available, version.