### PR TITLE
Enable testing with Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
         cache-dependency-path: |
-          **/ci.yml
+          **/test.yml
           **/requirements*.txt
 
     ### Installation of build-dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Two simple and hopefully uncontroversial items:
 * enable testing with Python 3.12 just to keep up with potential problems (none found)
 * fix a copy-paste typo in `test.yml` that was incorrectly calculating what changes should invalidate the pip cache.