### PR TITLE
Unit unicode symbol fix

### DIFF
--- a/sasdata/quantities/unit_parser.py
+++ b/sasdata/quantities/unit_parser.py
@@ -16,7 +16,7 @@ def split_unit_str(unit_str: str) -> list[str]:
 def validate_unit_str(unit_str: str) -> bool:
     """Validate whether unit_str is valid. This doesn't mean that the unit specified in unit_str exists but rather it
     only consists of letters, and numbers as a unit string should."""
-    return not fullmatch(r'[A-Za-zΩ%Å1-9\-\+/\ \.]+', unit_str) is None
+    return not fullmatch(r'[A-Za-zΩ%Å^1-9\-\+/\ \.]+', unit_str) is None
 
 def parse_single_unit(unit_str: str, unit_group: UnitGroup | None = None, longest_unit: bool = True) -> tuple[Unit | None, str]:
     """Attempts to find a single unit for unit_str. Return this unit, and the remaining string in a tuple. If a unit

--- a/sasdata/quantities/unit_parser.py
+++ b/sasdata/quantities/unit_parser.py
@@ -11,12 +11,12 @@ for group in all_units_groups:
 
 def split_unit_str(unit_str: str) -> list[str]:
     """Separate the letters from the numbers in unit_str"""
-    return findall(r'[A-Za-z]+|[-\d]+|/', unit_str)
+    return findall(r'[A-Za-zΩ%Å]+|[-\d]+|/', unit_str)
 
 def validate_unit_str(unit_str: str) -> bool:
     """Validate whether unit_str is valid. This doesn't mean that the unit specified in unit_str exists but rather it
     only consists of letters, and numbers as a unit string should."""
-    return not fullmatch(r'[A-Za-z1-9\-\+/\ \.]+', unit_str) is None
+    return not fullmatch(r'[A-Za-zΩ%Å1-9\-\+/\ \.]+', unit_str) is None
 
 def parse_single_unit(unit_str: str, unit_group: UnitGroup | None = None, longest_unit: bool = True) -> tuple[Unit | None, str]:
     """Attempts to find a single unit for unit_str. Return this unit, and the remaining string in a tuple. If a unit


### PR DESCRIPTION
Fixed tests that were failing due to symbols like Å, and Ω not being parsable due to them not being ASCII symbols. The solution is just to manually specify them in the regex; there are not many of them at the moment so it is fairly trivial. This way also makes sure that we don't include symbols that we don't want.

There is still a test failure for percentages. I think it parses the unit correctly but cannot find the right named unit for it. I'll look into this further.