### PR TITLE
Rework Metadata as Dataclasses

### DIFF
--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -12,9 +12,8 @@ from sasdata.data_backing import Group, key_tree
 
 class SasData:
     def __init__(self, name: str,
-                 data_contents: list[NamedQuantity],
+                 data_contents: dict[str, Quantity],
                  dataset_type: DatasetType,
-                 raw_metadata: Group,
                  metadata: Metadata,
                  verbose: bool=False):
 

--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TypeVar, Any, Self
+from typing import TypeVar, Any, Self, Optional
 from dataclasses import dataclass
 
 import numpy as np
@@ -15,7 +15,7 @@ class SasData:
                  data_contents: dict[str, Quantity],
                  dataset_type: DatasetType,
                  raw_metadata: Group,
-                 instrument: Instrument,
+                 instrument: Optional[Instrument],
                  verbose: bool=False):
 
         self.name = name

--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -12,7 +12,7 @@ from sasdata.data_backing import Group, key_tree
 
 class SasData:
     def __init__(self, name: str,
-                 data_contents: dict[str, Quantity],
+                 data_contents: list[NamedQuantity],
                  dataset_type: DatasetType,
                  raw_metadata: Group,
                  metadata: Metadata,
@@ -23,7 +23,6 @@ class SasData:
         if not all([key in dataset_type.optional or key in dataset_type.required for key in data_contents.keys()]):
             raise ValueError("Columns don't match the dataset type")
         self._data_contents = data_contents
-        self._raw_metadata = raw_metadata
         self._verbose = verbose
 
         self.metadata = metadata
@@ -65,7 +64,7 @@ class SasData:
     def __getitem__(self, item: str):
         return self._data_contents[item]
 
-    def summary(self, indent = "  ", include_raw=False):
+    def summary(self, indent = "  "):
         s = f"{self.name}\n"
 
         for data in self._data_contents:
@@ -74,8 +73,5 @@ class SasData:
         s += f"Metadata:\n"
         s += "\n"
         s += self.metadata.summary()
-
-        if include_raw:
-            s += key_tree(self._raw_metadata)
 
         return s

--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from sasdata.dataset_types import DatasetType, one_dim, two_dim
 from sasdata.quantities.quantity import NamedQuantity, Quantity
-from sasdata.metadata import Metadata
+from sasdata.metadata import Metadata, Instrument
 from sasdata.quantities.accessors import AccessorTarget
 from sasdata.data_backing import Group, key_tree
 
@@ -15,6 +15,7 @@ class SasData:
                  data_contents: dict[str, Quantity],
                  dataset_type: DatasetType,
                  raw_metadata: Group,
+                 instrument: Instrument,
                  verbose: bool=False):
 
         self.name = name
@@ -25,7 +26,7 @@ class SasData:
         self._raw_metadata = raw_metadata
         self._verbose = verbose
 
-        self.metadata = Metadata(AccessorTarget(raw_metadata, verbose=verbose))
+        self.metadata = Metadata(AccessorTarget(raw_metadata, verbose=verbose), instrument)
 
         # TODO: Could this be optional?
         self.dataset_type: DatasetType = dataset_type

--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -15,6 +15,7 @@ class SasData:
                  data_contents: dict[str, Quantity],
                  dataset_type: DatasetType,
                  raw_metadata: Group,
+                 sample: Optional[Instrument],
                  instrument: Optional[Instrument],
                  verbose: bool=False):
 
@@ -26,7 +27,7 @@ class SasData:
         self._raw_metadata = raw_metadata
         self._verbose = verbose
 
-        self.metadata = Metadata(AccessorTarget(raw_metadata, verbose=verbose), instrument)
+        self.metadata = Metadata(AccessorTarget(raw_metadata, verbose=verbose), instrument=instrument, sample=sample)
 
         # TODO: Could this be optional?
         self.dataset_type: DatasetType = dataset_type

--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TypeVar, Any, Self, Optional
+from typing import TypeVar, Any, Self
 from dataclasses import dataclass
 
 import numpy as np

--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -15,9 +15,7 @@ class SasData:
                  data_contents: dict[str, Quantity],
                  dataset_type: DatasetType,
                  raw_metadata: Group,
-                 process: list[Process],
-                 sample: Optional[Sample],
-                 instrument: Optional[Instrument],
+                 metadata: Metadata,
                  verbose: bool=False):
 
         self.name = name
@@ -28,7 +26,7 @@ class SasData:
         self._raw_metadata = raw_metadata
         self._verbose = verbose
 
-        self.metadata = Metadata(AccessorTarget(raw_metadata, verbose=verbose), process=process, instrument=instrument, sample=sample)
+        self.metadata = metadata
 
         # TODO: Could this be optional?
         self.dataset_type: DatasetType = dataset_type

--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from sasdata.dataset_types import DatasetType, one_dim, two_dim
 from sasdata.quantities.quantity import NamedQuantity, Quantity
-from sasdata.metadata import Metadata, Instrument, Process, Sample
+from sasdata.metadata import Metadata
 from sasdata.quantities.accessors import AccessorTarget
 from sasdata.data_backing import Group, key_tree
 

--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from sasdata.dataset_types import DatasetType, one_dim, two_dim
 from sasdata.quantities.quantity import NamedQuantity, Quantity
-from sasdata.metadata import Metadata, Instrument
+from sasdata.metadata import Metadata, Instrument, Process, Sample
 from sasdata.quantities.accessors import AccessorTarget
 from sasdata.data_backing import Group, key_tree
 
@@ -15,7 +15,8 @@ class SasData:
                  data_contents: dict[str, Quantity],
                  dataset_type: DatasetType,
                  raw_metadata: Group,
-                 sample: Optional[Instrument],
+                 process: list[Process],
+                 sample: Optional[Sample],
                  instrument: Optional[Instrument],
                  verbose: bool=False):
 
@@ -27,7 +28,7 @@ class SasData:
         self._raw_metadata = raw_metadata
         self._verbose = verbose
 
-        self.metadata = Metadata(AccessorTarget(raw_metadata, verbose=verbose), instrument=instrument, sample=sample)
+        self.metadata = Metadata(AccessorTarget(raw_metadata, verbose=verbose), process=process, instrument=instrument, sample=sample)
 
         # TODO: Could this be optional?
         self.dataset_type: DatasetType = dataset_type

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -158,20 +158,16 @@ class Sample:
         # return _str
 
 
+@dataclass(kw_only=True)
 class Process:
     """
     Class that holds information about the processes
     performed on the data.
     """
-    def __init__(self, target_object: AccessorTarget):
-        self.name = StringAccessor(target_object, "name")
-        self.date = StringAccessor(target_object, "date")
-        self.description = StringAccessor(target_object, "description")
-
-        #TODO: It seems like these might be lists of strings, this should be checked
-
-        self.term = StringAccessor(target_object, "term")
-        self.notes = StringAccessor(target_object, "notes")
+    name : Optional[ str ]
+    date : Optional[ str ]
+    description : Optional[ str ]
+    term : Optional[ str ]
 
     def single_line_desc(self):
         """
@@ -181,11 +177,10 @@ class Process:
 
     def summary(self):
         return (f"Process:\n"
-                f"    Name: {self.name.value}\n"
-                f"    Date: {self.date.value}\n"
-                f"    Description: {self.description.value}\n"
-                f"    Term: {self.term.value}\n"
-                f"    Notes: {self.notes.value}\n"
+                f"    Name: {self.name}\n"
+                f"    Date: {self.date}\n"
+                f"    Description: {self.description}\n"
+                f"    Term: {self.term}\n"
                 )
 
 class TransmissionSpectrum:
@@ -261,11 +256,11 @@ def decode_string(data):
         return str(data)
 
 class Metadata:
-    def __init__(self, target: AccessorTarget, sample: Optional[Sample], instrument: Optional[Instrument]):
+    def __init__(self, target: AccessorTarget, process: list[Process], sample: Optional[Sample], instrument: Optional[Instrument]):
         self._target = target
 
         self.instrument = instrument
-        self.process = Process(target.with_path_prefix("sasprocess|process"))
+        self.process = process
         self.sample = sample
         self.transmission_spectrum = TransmissionSpectrum(target.with_path_prefix("sastransmission_spectrum|transmission_spectrum"))
 
@@ -284,7 +279,7 @@ class Metadata:
                            "=======" +
             "="*len(self.run) + "\n\n" +
             f"Definition: {self.title}\n" +
-            self.process.summary() +
+            "".join([p.summary() for p in self.process]) +
             self.sample.summary() +
             (self.instrument.summary() if self.instrument else "") +
             self.transmission_spectrum.summary())

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -251,28 +251,23 @@ def decode_string(data):
         return str(data)
 
 class Metadata:
-    def __init__(self, target: AccessorTarget, process: list[Process], sample: Optional[Sample], instrument: Optional[Instrument]):
-        self._target = target
-
+    def __init__(self, target: AccessorTarget, title: Optional[str], run: list[str], definition: Optional[str], process: list[Process], sample: Optional[Sample], instrument: Optional[Instrument]):
         self.instrument = instrument
         self.process = process
         self.sample = sample
         self.transmission_spectrum = TransmissionSpectrum(target.with_path_prefix("sastransmission_spectrum|transmission_spectrum"))
 
-        self._title = StringAccessor(target, "title")
-        self._run = StringAccessor(target, "run")
-        self._definition = StringAccessor(target, "definition")
-
-        self.title: str = decode_string(self._title.value)
-        self.run: str = decode_string(self._run.value)
-        self.definition: str = decode_string(self._definition.value)
+        self.title = title
+        self.run = run
+        self.definition = definition
 
     def summary(self):
+        run_string = self.run[0] if len(self.run) == 1 else self.run
         return (
-            f"  {self.title}, Run: {self.run}\n" +
+            f"  {self.title}, Run: {run_string}\n" +
             "  " + "="*len(self.title) +
                            "=======" +
-            "="*len(self.run) + "\n\n" +
+            "="*len(run_string) + "\n\n" +
             f"Definition: {self.title}\n" +
             "".join([p.summary() for p in self.process]) +
             self.sample.summary() +

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -293,7 +293,7 @@ def decode_string(data):
         return str(data)
 
 class Metadata:
-    def __init__(self, target: AccessorTarget, instrument: Instrument):
+    def __init__(self, target: AccessorTarget, instrument: Optional[Instrument]):
         self._target = target
 
         self.instrument = instrument

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -105,7 +105,6 @@ class BeamSize:
     y: Optional[Quantity[float]]
     z: Optional[Quantity[float]]
 
-
 @dataclass
 class Source:
     radiation: str

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -1,3 +1,14 @@
+"""
+Contains classes describing the metadata for a scattering run
+
+The metadata is structures around the CANSas format version 1.1, found at
+https://www.cansas.org/formats/canSAS1d/1.1/doc/specification.html
+
+Metadata from other file formats should be massaged to fit into the data classes presented here.
+Any useful metadata which cannot be included in these classes represent a bug in the CANSas format.
+
+"""
+
 from tokenize import String
 from typing import Optional
 from dataclasses import dataclass
@@ -174,7 +185,7 @@ class Metadata:
     title: Optional[str]
     run: list[str]
     definition: Optional[str]
-    process: list[str]
+    process: list[Process]
     sample: Optional[Sample]
     instrument: Optional[Instrument]
 

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -258,11 +258,11 @@ class TransmissionSpectrum:
                 f"    Transmission:     {self.transmission.value}\n")
 
 
+@dataclass
 class Instrument:
-    def __init__(self, target: AccessorTarget, collimations: list[Collimation], source: Source, detector: list[Detector]):
-        self.collimations = collimations
-        self.detector = detector
-        self.source = source
+    collimations : list[Collimation]
+    source : Source
+    detector : list[Detector]
 
     def summary(self):
         return (

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -11,14 +11,14 @@ from sasdata.quantities.absolute_temperature import AbsoluteTemperatureAccessor
 from sasdata.quantities.accessors import StringAccessor, LengthAccessor, AngleAccessor, QuantityAccessor, \
     DimensionlessAccessor, FloatAccessor, TemperatureAccessor, AccessorTarget
 
-@dataclass
+@dataclass(kw_only=True)
 class Vec3:
     """A three-vector of measured quantities"""
     x : Optional[Quantity[float]]
     y : Optional[Quantity[float]]
     z : Optional[Quantity[float]]
 
-@dataclass
+@dataclass(kw_only=True)
 class Rot3:
     """A measured rotation in 3-space"""
     roll : Optional[Quantity[float]]
@@ -31,7 +31,7 @@ def parse_length(node) -> Quantity[float]:
     unit = node.attrs["units"]
     return Quantity(magnitude, units.symbol_lookup[unit])
 
-@dataclass
+@dataclass(kw_only=True)
 class Detector:
     """
     Detector information
@@ -56,7 +56,7 @@ class Detector:
                 f"   Slit length:  {self.slit_length}\n")
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Aperture:
     distance: Optional[Quantity[float]]
     size: Optional[Vec3]
@@ -70,7 +70,7 @@ class Aperture:
                 f"  Aperture size: {self.size}\n"
                 f"  Aperture distance: {self.distance}\n")
 
-@dataclass
+@dataclass(kw_only=True)
 class Collimation:
     """
     Class to hold collimation information
@@ -86,14 +86,12 @@ class Collimation:
             f"Collimation:\n"
             f"   Length: {self.length}\n")
 
-@dataclass
+@dataclass(kw_only=True)
 class BeamSize:
     name: Optional[str]
-    x: Optional[Quantity[float]]
-    y: Optional[Quantity[float]]
-    z: Optional[Quantity[float]]
+    size: Optional[Vec3]
 
-@dataclass
+@dataclass(kw_only=True)
 class Source:
     radiation: str
     beam_shape: Optional[str]

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -128,60 +128,28 @@ MUON = 'muon'
 ELECTRON = 'electron'
 
 
+@dataclass(kw_only=True)
 class Sample:
     """
     Class to hold the sample description
     """
-    def __init__(self, target_object: AccessorTarget):
-
-        # Short name for sample
-        self.name = StringAccessor(target_object, "name")
-        # ID
-
-        self.sample_id = StringAccessor(target_object, "id")
-
-        # Thickness [float] [mm]
-        self.thickness = LengthAccessor(target_object,
-                                        "thickness",
-                                        "thickness.units",
-                                        default_unit=units.millimeters)
-
-        # Transmission [float] [fraction]
-        self.transmission = FloatAccessor(target_object,"transmission")
-
-        # Temperature [float] [No Default]
-        self.temperature = AbsoluteTemperatureAccessor(target_object,
-                                                       "temperature",
-                                                       "temperature.unit",
-                                                       default_unit=units.kelvin)
-        # Position [Vector] [mm]
-        self.position = LengthAccessor[ArrayLike](target_object,
-                                                  "position",
-                                                  "position.unit",
-                                                  default_unit=units.millimeters)
-
-        # Orientation [Vector] [degrees]
-        self.orientation = AngleAccessor[ArrayLike](target_object,
-                                                    "orientation",
-                                                    "orientation.unit",
-                                                    default_unit=units.degrees)
-
-        # Details
-        self.details = StringAccessor(target_object, "details")
-
-
-        # SESANS zacceptance
-        zacceptance = (0,"")
-        yacceptance = (0,"")
+    name: Optional[str]
+    sample_id : Optional[str]
+    thickness : Optional[Quantity[float]]
+    transmission: Optional[float]
+    temperature : Optional[Quantity[float]]
+    position : Optional[Vec3]
+    orientation : Optional[Rot3]
+    details : list[str]
 
     def summary(self) -> str:
         return (f"Sample:\n"
-                f"   ID:           {self.sample_id.value}\n"
-                f"   Transmission: {self.transmission.value}\n"
-                f"   Thickness:    {self.thickness.value}\n"
-                f"   Temperature:  {self.temperature.value}\n"
-                f"   Position:     {self.position.value}\n"
-                f"   Orientation:  {self.orientation.value}\n")
+                f"   ID:           {self.sample_id}\n"
+                f"   Transmission: {self.transmission}\n"
+                f"   Thickness:    {self.thickness}\n"
+                f"   Temperature:  {self.temperature}\n"
+                f"   Position:     {self.position}\n"
+                f"   Orientation:  {self.orientation}\n")
         #
         # _str += "   Details:\n"
         # for item in self.details:
@@ -293,12 +261,12 @@ def decode_string(data):
         return str(data)
 
 class Metadata:
-    def __init__(self, target: AccessorTarget, instrument: Optional[Instrument]):
+    def __init__(self, target: AccessorTarget, sample: Optional[Sample], instrument: Optional[Instrument]):
         self._target = target
 
         self.instrument = instrument
         self.process = Process(target.with_path_prefix("sasprocess|process"))
-        self.sample = Sample(target.with_path_prefix("sassample|sample"))
+        self.sample = sample
         self.transmission_spectrum = TransmissionSpectrum(target.with_path_prefix("sastransmission_spectrum|transmission_spectrum"))
 
         self._title = StringAccessor(target, "title")

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -102,14 +102,9 @@ class Source:
     wavelength_spread : Optional[Quantity[float]]
 
     def summary(self) -> str:
-        if self.radiation is None and self.type.value and self.probe_particle.value:
-            radiation = f"{self.type.value} {self.probe_particle.value}"
-        else:
-            radiation = f"{self.radiation}"
-
         return (
             f"Source:\n"
-            f"    Radiation:         {radiation}\n"
+            f"    Radiation:         {self.radiation}\n"
             f"    Shape:             {self.beam_shape}\n"
             f"    Wavelength:        {self.wavelength}\n"
             f"    Min. Wavelength:   {self.wavelength_min}\n"

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -62,7 +62,7 @@ class Aperture:
     size: Optional[Vec3]
     size_name: Optional[str]
     name: Optional[str]
-    apType: Optional[str]
+    type_: Optional[str]
 
     def summary(self):
         return (f"Aperture:\n"

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -1,5 +1,6 @@
 from tokenize import String
 from typing import Optional
+from dataclasses import dataclass
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -67,25 +68,13 @@ class Detector:
                 f"   Slit length:  {self.slit_length.value}\n")
 
 
+@dataclass
 class Aperture:
-
-    def __init__(self, distance: Optional[Quantity[float]], size: Optional[tuple[ Optional[Quantity[float]], Optional[Quantity[float]], Optional[Quantity[float]] ]], size_name: Optional[str], name: Optional[str], apType: Optional[str]):
-
-        # Name
-        self.name = name
-
-        # Type
-        self.type = apType
-
-        # Size name - TODO: What is the name of a size
-        self.size_name = size_name
-
-        # Aperture size [Vector] # TODO: Wat!?!
-        self.size = size
-
-        # Aperture distance [float]
-        self.distance = distance
-
+    distance: Optional[Quantity[float]]
+    size: Optional[tuple[ Optional[Quantity[float]],Optional[Quantity[float]], Optional[Quantity[float]] ]]
+    size_name: Optional[str]
+    name: Optional[str]
+    apType: Optional[str]
 
     def summary(self):
         return (f"Aperture:\n"
@@ -93,17 +82,14 @@ class Aperture:
                 f"  Aperture size: {self.size}\n"
                 f"  Aperture distance: {self.distance}\n")
 
+@dataclass
 class Collimation:
     """
     Class to hold collimation information
     """
 
-    def __init__(self, length: Quantity[float], apertures: list[Aperture]):
-
-        # Length [float] [mm]
-        self.length = length
-        # TODO - parse units properly
-        self.apertures = apertures
+    length: Quantity[float]
+    apertures: list[Aperture]
 
     def summary(self):
 

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -12,60 +12,29 @@ from sasdata.quantities.accessors import StringAccessor, LengthAccessor, AngleAc
     DimensionlessAccessor, FloatAccessor, TemperatureAccessor, AccessorTarget
 
 
+@dataclass
 class Detector:
     """
     Detector information
     """
+    name : str
+    distance : Optional[Quantity[float]]
+    offset : Optional[Quantity[float]]
+    orientation : Optional[Quantity[float]]
+    beam_center : Optional[Quantity[float]]
+    pixel_size : Optional[Quantity[float]]
+    slit_length : Optional[Quantity[float]]
 
-    def __init__(self, target_object: AccessorTarget):
-
-        # Name of the instrument [string]
-        self.name = StringAccessor(target_object, "name")
-
-        # Sample to detector distance [float] [mm]
-        self.distance = LengthAccessor[float](target_object,
-                                              "distance",
-                                              "distance.units",
-                                              default_unit=units.millimeters)
-
-        # Offset of this detector position in X, Y,
-        # (and Z if necessary) [Vector] [mm]
-        self.offset = LengthAccessor[ArrayLike](target_object,
-                                                "offset",
-                                                "offset.units",
-                                                default_unit=units.millimeters)
-
-        self.orientation = AngleAccessor[ArrayLike](target_object,
-                                                    "orientation",
-                                                    "orientation.units",
-                                                    default_unit=units.degrees)
-
-        self.beam_center = LengthAccessor[ArrayLike](target_object,
-                                                     "beam_center",
-                                                     "beam_center.units",
-                                                     default_unit=units.millimeters)
-
-        # Pixel size in X, Y, (and Z if necessary) [Vector] [mm]
-        self.pixel_size = LengthAccessor[ArrayLike](target_object,
-                                                    "pixel_size",
-                                                    "pixel_size.units",
-                                                    default_unit=units.millimeters)
-
-        # Slit length of the instrument for this detector.[float] [mm]
-        self.slit_length = LengthAccessor[float](target_object,
-                                                 "slit_length",
-                                                 "slit_length.units",
-                                                 default_unit=units.millimeters)
 
     def summary(self):
         return (f"Detector:\n"
-                f"   Name:         {self.name.value}\n"
-                f"   Distance:     {self.distance.value}\n"
-                f"   Offset:       {self.offset.value}\n"
-                f"   Orientation:  {self.orientation.value}\n"
-                f"   Beam center:  {self.beam_center.value}\n"
-                f"   Pixel size:   {self.pixel_size.value}\n"
-                f"   Slit length:  {self.slit_length.value}\n")
+                f"   Name:         {self.name}\n"
+                f"   Distance:     {self.distance}\n"
+                f"   Offset:       {self.offset}\n"
+                f"   Orientation:  {self.orientation}\n"
+                f"   Beam center:  {self.beam_center}\n"
+                f"   Pixel size:   {self.pixel_size}\n"
+                f"   Slit length:  {self.slit_length}\n")
 
 
 @dataclass
@@ -271,15 +240,15 @@ class TransmissionSpectrum:
 
 
 class Instrument:
-    def __init__(self, target: AccessorTarget, collimations: list[Collimation], source: Source):
+    def __init__(self, target: AccessorTarget, collimations: list[Collimation], source: Source, detector: list[Detector]):
         self.collimations = collimations
-        self.detector = Detector(target.with_path_prefix("sasdetector|detector"))
+        self.detector = detector
         self.source = source
 
     def summary(self):
         return (
             "\n".join([c.summary() for c in self.collimations]) +
-            self.detector.summary() +
+            "".join([d.summary() for d in self.detector]) +
             self.source.summary())
 
 def decode_string(data):

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -25,12 +25,6 @@ class Rot3:
     pitch : Optional[Quantity[float]]
     yaw : Optional[Quantity[float]]
 
-def parse_length(node) -> Quantity[float]:
-    """Pull a single quantity with length units out of an HDF5 node"""
-    magnitude = node.astype(float)[0]
-    unit = node.attrs["units"]
-    return Quantity(magnitude, units.symbol_lookup[unit])
-
 @dataclass(kw_only=True)
 class Detector:
     """
@@ -113,16 +107,6 @@ class Source:
             f"    Beam Size:         {self.beam_size}\n"
         )
 
-
-"""
-Definitions of radiation types
-"""
-NEUTRON = 'neutron'
-XRAY = 'x-ray'
-MUON = 'muon'
-ELECTRON = 'electron'
-
-
 @dataclass(kw_only=True)
 class Sample:
     """
@@ -145,12 +129,6 @@ class Sample:
                 f"   Temperature:  {self.temperature}\n"
                 f"   Position:     {self.position}\n"
                 f"   Orientation:  {self.orientation}\n")
-        #
-        # _str += "   Details:\n"
-        # for item in self.details:
-        #     _str += "      %s\n" % item
-        #
-        # return _str
 
 
 @dataclass(kw_only=True)
@@ -190,30 +168,6 @@ class Instrument:
             "\n".join([c.summary() for c in self.collimations]) +
             "".join([d.summary() for d in self.detector]) +
             self.source.summary())
-
-def decode_string(data):
-    """ This is some crazy stuff"""
-
-    if isinstance(data, str):
-        return data
-
-    elif isinstance(data, np.ndarray):
-
-        if data.dtype == object:
-
-            data = data.reshape(-1)
-            data = data[0]
-
-            if isinstance(data, bytes):
-                return data.decode("utf-8")
-
-            return str(data)
-
-        else:
-            return data.tobytes().decode("utf-8")
-
-    else:
-        return str(data)
 
 @dataclass(kw_only=True)
 class Metadata:

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -102,26 +102,20 @@ class Collimation:
     Class to hold collimation information
     """
 
-    def __init__(self, target_object: AccessorTarget):
+    def __init__(self, name, length):
 
         # Name
-        self.name = StringAccessor(target_object, "name")
+        self.name = name
         # Length [float] [mm]
-        self.length = LengthAccessor[float](target_object,
-                                              "length",
-                                              "length.units",
-                                              default_unit=units.millimeters)
-
-
-        # Todo - how do we handle this
-        # self.collimator = Collimation(target_object)
+        self.length = length
+        # TODO - parse units properly
 
     def summary(self):
 
         #TODO collimation stuff
         return (
             f"Collimation:\n"
-            f"   Length: {self.length.value}\n")
+            f"   Length: {self.length}\n")
 
 
 
@@ -337,16 +331,16 @@ class TransmissionSpectrum:
 
 
 class Instrument:
-    def __init__(self, target: AccessorTarget):
+    def __init__(self, target: AccessorTarget, collimations: list[Collimation]):
         self.aperture = Aperture(target.with_path_prefix("sasaperture|aperture"))
-        self.collimation = Collimation(target.with_path_prefix("sascollimation|collimation"))
+        self.collimations = collimations
         self.detector = Detector(target.with_path_prefix("sasdetector|detector"))
         self.source = Source(target.with_path_prefix("sassource|source"))
 
     def summary(self):
         return (
             self.aperture.summary() +
-            self.collimation.summary() +
+            "\n".join([c.summary for c in self.collimations]) +
             self.detector.summary() +
             self.source.summary())
 
@@ -375,10 +369,10 @@ def decode_string(data):
         return str(data)
 
 class Metadata:
-    def __init__(self, target: AccessorTarget):
+    def __init__(self, target: AccessorTarget, instrument: Instrument):
         self._target = target
 
-        self.instrument = Instrument(target.with_path_prefix("sasinstrument|instrument"))
+        self.instrument = instrument
         self.process = Process(target.with_path_prefix("sasprocess|process"))
         self.sample = Sample(target.with_path_prefix("sassample|sample"))
         self.transmission_spectrum = TransmissionSpectrum(target.with_path_prefix("sastransmission_spectrum|transmission_spectrum"))

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -11,6 +11,19 @@ from sasdata.quantities.absolute_temperature import AbsoluteTemperatureAccessor
 from sasdata.quantities.accessors import StringAccessor, LengthAccessor, AngleAccessor, QuantityAccessor, \
     DimensionlessAccessor, FloatAccessor, TemperatureAccessor, AccessorTarget
 
+@dataclass
+class Vec3:
+    """A three-vector of measured quantities"""
+    x : Optional[Quantity[float]]
+    y : Optional[Quantity[float]]
+    z : Optional[Quantity[float]]
+
+@dataclass
+class Rot3:
+    """A measured rotation in 3-space"""
+    roll : Optional[Quantity[float]]
+    pitch : Optional[Quantity[float]]
+    yaw : Optional[Quantity[float]]
 
 @dataclass
 class Detector:
@@ -19,10 +32,10 @@ class Detector:
     """
     name : Optional[str]
     distance : Optional[Quantity[float]]
-    offset : Optional[Quantity[float]]
+    offset : Optional[Vec3]
     orientation : Optional[Quantity[float]]
-    beam_center : Optional[Quantity[float]]
-    pixel_size : Optional[Quantity[float]]
+    beam_center : Optional[Vec3]
+    pixel_size : Optional[Vec3]
     slit_length : Optional[Quantity[float]]
 
 

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -17,7 +17,7 @@ class Detector:
     """
     Detector information
     """
-    name : str
+    name : Optional[str]
     distance : Optional[Quantity[float]]
     offset : Optional[Quantity[float]]
     orientation : Optional[Quantity[float]]
@@ -77,12 +77,12 @@ class BeamSize:
 @dataclass
 class Source:
     radiation: str
-    beam_shape: str
+    beam_shape: Optional[str]
     beam_size: Optional[BeamSize]
-    wavelength : Quantity[float]
-    wavelength_min : Quantity[float]
-    wavelength_max : Quantity[float]
-    wavelength_spread : Quantity[float]
+    wavelength : Optional[Quantity[float]]
+    wavelength_min : Optional[Quantity[float]]
+    wavelength_max : Optional[Quantity[float]]
+    wavelength_spread : Optional[Quantity[float]]
 
     def summary(self) -> str:
         if self.radiation is None and self.type.value and self.probe_particle.value:

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -25,6 +25,12 @@ class Rot3:
     pitch : Optional[Quantity[float]]
     yaw : Optional[Quantity[float]]
 
+def parse_length(node) -> Quantity[float]:
+    """Pull a single quantity with length units out of an HDF5 node"""
+    magnitude = node.astype(float)[0]
+    unit = node.attrs["units"]
+    return Quantity(magnitude, units.symbol_lookup[unit])
+
 @dataclass
 class Detector:
     """
@@ -33,7 +39,7 @@ class Detector:
     name : Optional[str]
     distance : Optional[Quantity[float]]
     offset : Optional[Vec3]
-    orientation : Optional[Quantity[float]]
+    orientation : Optional[Rot3]
     beam_center : Optional[Vec3]
     pixel_size : Optional[Vec3]
     slit_length : Optional[Quantity[float]]
@@ -53,7 +59,7 @@ class Detector:
 @dataclass
 class Aperture:
     distance: Optional[Quantity[float]]
-    size: Optional[tuple[ Optional[Quantity[float]],Optional[Quantity[float]], Optional[Quantity[float]] ]]
+    size: Optional[Vec3]
     size_name: Optional[str]
     name: Optional[str]
     apType: Optional[str]

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -178,41 +178,6 @@ class Process:
                 f"    Term: {self.term}\n"
                 )
 
-class TransmissionSpectrum:
-    """
-    Class that holds information about transmission spectrum
-    for white beams and spallation sources.
-    """
-    def __init__(self, target_object: AccessorTarget):
-        # TODO: Needs to be multiple instances
-        self.name = StringAccessor(target_object, "name")
-        self.timestamp = StringAccessor(target_object, "timestamp")
-
-        # Wavelength (float) [A]
-        self.wavelength = LengthAccessor[ArrayLike](target_object,
-                                                    "wavelength",
-                                                    "wavelength.units")
-
-        # Transmission (float) [unit less]
-        self.transmission = DimensionlessAccessor[ArrayLike](target_object,
-                                                             "transmission",
-                                                             "units",
-                                                             default_unit=units.none)
-
-        # Transmission Deviation (float) [unit less]
-        self.transmission_deviation = DimensionlessAccessor[ArrayLike](target_object,
-                                                                       "transmission_deviation",
-                                                                       "transmission_deviation.units",
-                                                                       default_unit=units.none)
-
-
-    def summary(self) -> str:
-        return (f"Transmission Spectrum:\n"
-                f"    Name:             {self.name.value}\n"
-                f"    Timestamp:        {self.timestamp.value}\n"
-                f"    Wavelengths:      {self.wavelength.value}\n"
-                f"    Transmission:     {self.transmission.value}\n")
-
 
 @dataclass
 class Instrument:
@@ -250,16 +215,14 @@ def decode_string(data):
     else:
         return str(data)
 
+@dataclass(kw_only=True)
 class Metadata:
-    def __init__(self, target: AccessorTarget, title: Optional[str], run: list[str], definition: Optional[str], process: list[Process], sample: Optional[Sample], instrument: Optional[Instrument]):
-        self.instrument = instrument
-        self.process = process
-        self.sample = sample
-        self.transmission_spectrum = TransmissionSpectrum(target.with_path_prefix("sastransmission_spectrum|transmission_spectrum"))
-
-        self.title = title
-        self.run = run
-        self.definition = definition
+    title: Optional[str]
+    run: list[str]
+    definition: Optional[str]
+    process: list[str]
+    sample: Optional[Sample]
+    instrument: Optional[Instrument]
 
     def summary(self):
         run_string = self.run[0] if len(self.run) == 1 else self.run
@@ -271,5 +234,4 @@ class Metadata:
             f"Definition: {self.title}\n" +
             "".join([p.summary() for p in self.process]) +
             self.sample.summary() +
-            (self.instrument.summary() if self.instrument else "") +
-            self.transmission_spectrum.summary())
+            (self.instrument.summary() if self.instrument else ""))

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -111,6 +111,8 @@ def connected_data(node: SASDataGroup, name_prefix="") -> list[NamedQuantity]:
 
     return output
 
+### Begin metadata parsing code
+
 def parse_quantity(node) -> Quantity[float]:
     """Pull a single quantity with length units out of an HDF5 node"""
     magnitude = node.astype(float)[0]
@@ -234,8 +236,9 @@ def parse_metadata(node) -> Metadata:
     title = opt_parse(node, "title", parse_string)
     run = [parse_string(node[r]) for r in node if "run" in r]
     definition = opt_parse(node, "definition", parse_string)
-
     return Metadata(process=process, instrument=instrument, sample=sample, title=title, run=run, definition=definition)
+
+### End Metadata parsing code
 
 
 def load_data(filename) -> list[SasData]:

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -137,18 +137,10 @@ def parse_apterture(node) -> Aperture:
 
 def parse_beam_size(node) -> BeamSize:
     name = None
-    x = None
-    y = None
-    z = None
     if "name" in node.attrs:
         name = node.atrs["name"].asstr()[0]
-    if "x" in node:
-        x = parse_quantity(node["x"])
-    if "y" in node:
-        y = parse_quantity(node["y"])
-    if "z" in node:
-        z = parse_quantity(node["z"])
-    return BeamSize(name=name, x=x, y=y, z=z)
+    size = parse_vec3(node)
+    return BeamSize(name=name, size=size)
 
 def parse_source(node) -> Source:
     beam_shape = None

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -16,7 +16,7 @@ from sasdata.data_backing import Dataset as SASDataDataset, Group as SASDataGrou
 from sasdata.metadata import Instrument, Collimation, Aperture, Source, BeamSize, Detector
 from sasdata.quantities.accessors import AccessorTarget
 
-from sasdata.quantities.quantity import NamedQuantity
+from sasdata.quantities.quantity import NamedQuantity, Quantity
 from sasdata.quantities import units
 from sasdata.quantities.unit_parser import parse
 
@@ -180,7 +180,13 @@ def parse_source(node) -> Source:
 
 def parse_detector(node) -> Detector:
     name = None
+    if "name" in node:
+        name = node["name"].asstr()[0]
     distance = None
+    if "SDD" in node:
+        magnitude = node["SDD"].astype(float)[0]
+        unit = node["SDD"].attrs["units"]
+        distance = Quantity(magnitude, units.symbol_lookup[unit])
     offset = None
     orientation = None
     beam_center = None

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -110,16 +110,14 @@ def connected_data(node: SASDataGroup, name_prefix="") -> list[NamedQuantity]:
 
 
 def parse_collimations(node) -> list[Collimation]:
-    if "sasinstrument" not in node["sasentry01"]:
-        return []
     return [
         Collimation(name=None, length=x)
-        for x in node["sasentry01"]["sasinstrument"]["sascollimation01"]
+        for x in node if "collimation" in x
     ]
 
 
 def parse_instrument(raw, node) -> Instrument:
-    collimations = parse_collimations(node)
+    collimations = parse_collimations(node["sasinstrument"])
     return Instrument(raw, collimations=collimations)
 
 
@@ -155,7 +153,7 @@ def load_data(filename) -> list[SasData]:
                     data_contents=data_contents,
                     raw_metadata=SASDataGroup("root", raw_metadata),
                     instrument=parse_instrument(
-                        AccessorTarget(SASDataGroup("root", raw_metadata)).with_path_prefix("sasinstrument|instrument"), f
+                        AccessorTarget(SASDataGroup("root", raw_metadata)).with_path_prefix("sasinstrument|instrument"), f["sasentry01"]
                     ),
                     verbose=False,
                 )

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -147,8 +147,8 @@ def load_data(filename) -> list[SasData]:
 
 
 
+if __name__ == "__main__":
+    data = load_data(test_file)
 
-data = load_data(test_file)
-
-for dataset in data:
-    print(dataset.summary(include_raw=False))
+    for dataset in data:
+        print(dataset.summary(include_raw=False))

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -67,7 +67,7 @@ def recurse_hdf5(hdf5_entry):
 GET_UNITS_FROM_ELSEWHERE = units.meters
 
 
-def connected_data(node: SASDataGroup, name_prefix="") -> dict[str, NamedQuantity]:
+def connected_data(node: SASDataGroup, name_prefix="") -> dict[str, Quantity]:
     """In the context of NeXus files, load a group of data entries that are organised together
     match up the units and errors with their values"""
     # Gather together data with its error terms
@@ -99,7 +99,7 @@ def connected_data(node: SASDataGroup, name_prefix="") -> dict[str, NamedQuantit
 
         entries[name] = quantity
 
-    output = {}
+    output : dict[str, Quantity] = {}
 
     for name, entry in entries.items():
         if name not in uncertainties:
@@ -244,12 +244,12 @@ def parse_metadata(node : HDF5Group) -> Metadata:
 
 def load_data(filename) -> dict[str, SasData]:
     with h5py.File(filename, "r") as f:
-        loaded_data: list[SasData] = []
+        loaded_data: dict[str, SasData] = {}
 
         for root_key in f.keys():
             entry = f[root_key]
 
-            data_contents : dict[str, NamedQuantity] = {}
+            data_contents : dict[str, Quantity] = {}
 
             entry_keys = [key for key in entry if "entry" in key]
 
@@ -266,15 +266,13 @@ def load_data(filename) -> dict[str, SasData]:
 
             metadata = parse_metadata(f[root_key])
 
-            loaded_data.append(
-                SasData(
+            loaded_data[root_key] = SasData(
                     name=root_key,
                     dataset_type=one_dim,
                     data_contents=data_contents,
                     metadata=metadata,
                     verbose=False,
                 )
-            )
 
         return loaded_data
 
@@ -282,5 +280,5 @@ def load_data(filename) -> dict[str, SasData]:
 if __name__ == "__main__":
     data = load_data(test_file)
 
-    for dataset in data:
-        print(dataset.summary(include_raw=False))
+    for dataset in data.values():
+        print(dataset.summary())

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -118,26 +118,22 @@ def parse_quantity(node) -> Quantity[float]:
     return Quantity(magnitude, units.symbol_lookup[unit])
 
 
-def parse_apertures(node) -> list[Aperture]:
-    result = []
-    aps = [a for a in node if "aperture" in a]
-    for ap in aps:
-        distance = None
-        size = None
-        if "distance" in node[ap]:
-            distance = parse_quantity(node[ap]["distance"])
-        if "size" in node[ap]:
-            x = y = z = None
-            if "x" in node[ap]:
-                x = parse_quantity(node[ap]["size"]["x"])
-            if "y" in node[ap]:
-                y = parse_quantity(node[ap]["size"]["y"])
-            if "z" in node[ap]:
-                z = parse_quantity(node[ap]["size"]["z"])
-            if x is not None or y is not None or z is not None:
-                size = (x, y, z)
-        result.append(Aperture(distance=distance, size=size, size_name=size_name, name=name, apType=apType))
-    return result
+def parse_apterture(node) -> Aperture:
+    distance = None
+    size = None
+    size_name = None
+    apType = None
+    if "name" in node.atrs:
+        name = node.attrs["name"].asstr()[0]
+    if "type" in node.atrs:
+        apType = node.attrs["type"].asstr()[0]
+    if "distance" in node:
+        distance = parse_quantity(node["distance"])
+    if "size" in node:
+        size = parse_vec3(node["size"])
+        if "name" in node.attrs:
+            size_name = node.attrs["name"].asstr()[0]
+    return Aperture(distance=distance, size=size, size_name=size_name, name=name, apType=apType)
 
 def parse_beam_size(node) -> BeamSize:
     name = None
@@ -198,11 +194,11 @@ def parse_rot3(node) -> Rot3:
     """Parse a measured rotation"""
     roll = pitch = yaw = None
     if "roll" in node:
-        roll = parse_angle(node["roll"])
+        roll = parse_quantity(node["roll"])
     if "pitch" in node:
-        pitch = parse_angle(node["pitch"])
+        pitch = parse_quantity(node["pitch"])
     if "yaw" in node:
-        yaw = parse_angle(node["yaw"])
+        yaw = parse_quantity(node["yaw"])
     return Rot3(roll=roll, pitch=pitch, yaw=yaw)
 
 def parse_detector(node) -> Detector:
@@ -237,7 +233,7 @@ def parse_collimation(node) -> Collimation:
         length = node["length"]
     else:
         length = None
-    return Collimation(length=length, apertures=parse_apertures(node))
+    return Collimation(length=length, apertures=[parse_apterture(node[ap]) for ap in node if "aperture" in ap])
 
 
 def parse_instrument(raw, node) -> Instrument:

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -13,7 +13,7 @@ from h5py._hl.group import Group as HDF5Group
 
 from sasdata.data import SasData
 from sasdata.data_backing import Dataset as SASDataDataset, Group as SASDataGroup
-from sasdata.metadata import Instrument, Collimation, Aperture, Source, BeamSize, Detector, Vec3, Rot3, Sample, Process
+from sasdata.metadata import Instrument, Collimation, Aperture, Source, BeamSize, Detector, Vec3, Rot3, Sample, Process, Metadata
 from sasdata.quantities.accessors import AccessorTarget
 
 from sasdata.quantities.quantity import NamedQuantity, Quantity
@@ -257,15 +257,18 @@ def load_data(filename) -> list[SasData]:
             instrument = opt_parse(f["sasentry01"], "sasinstrument", parse_instrument)
             sample = opt_parse(f["sasentry01"], "sassample", parse_sample)
             process = [parse_process(f["sasentry01"][p]) for p in f["sasentry01"] if "sasprocess" in p]
+            title = opt_parse(f["sasentry01"], "title", parse_string)
+            run = [parse_string(f["sasentry01"][r]) for r in f["sasentry01"] if "run" in r]
+            definition = opt_parse(f["sasentry01"], "definition", parse_string)
+
+            metadata = Metadata(AccessorTarget(SASDataGroup("root", raw_metadata),verbose=False), process=process, instrument=instrument, sample=sample, title=title, run=run, definition=definition)
 
             loaded_data.append(
                 SasData(
                     name=root_key,
                     data_contents=data_contents,
                     raw_metadata=SASDataGroup("root", raw_metadata),
-                    process=process,
-                    sample=sample,
-                    instrument=instrument,
+                    metadata=metadata,
                     verbose=False,
                 )
             )

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -13,7 +13,7 @@ from h5py._hl.group import Group as HDF5Group
 
 from sasdata.data import SasData
 from sasdata.data_backing import Dataset as SASDataDataset, Group as SASDataGroup
-from sasdata.metadata import Instrument, Collimation, Aperture, Source, BeamSize
+from sasdata.metadata import Instrument, Collimation, Aperture, Source, BeamSize, Detector
 from sasdata.quantities.accessors import AccessorTarget
 
 from sasdata.quantities.quantity import NamedQuantity
@@ -178,6 +178,18 @@ def parse_source(node) -> Source:
         wavelength_spread=wavelength_spread,
     )
 
+def parse_detector(node) -> Detector:
+    name = None
+    distance = None
+    offset = None
+    orientation = None
+    beam_center = None
+    pixel_size = None
+    slit_length = None
+
+    return Detector(name=name, distance=distance, offset=offset, orientation=orientation, beam_center=beam_center, pixel_size=pixel_size, slit_length=slit_length)
+
+
 
 def parse_collimation(node) -> Collimation:
     if "length" in node:
@@ -196,6 +208,7 @@ def parse_instrument(raw, node) -> Instrument:
     return Instrument(
         raw,
         collimations=collimations,
+        detector=[parse_detector(node[d]) for d in node if "detector" in d],
         source=parse_source(node["sassource"]),
     )
 

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -12,6 +12,7 @@ from h5py._hl.group import Group as HDF5Group
 
 
 from sasdata.data import SasData
+from sasdata.dataset_types import one_dim
 from sasdata.data_backing import Dataset as SASDataDataset, Group as SASDataGroup
 from sasdata.metadata import Instrument, Collimation, Aperture, Source, BeamSize, Detector, Vec3, Rot3, Sample, Process, Metadata
 from sasdata.quantities.accessors import AccessorTarget
@@ -66,7 +67,7 @@ def recurse_hdf5(hdf5_entry):
 GET_UNITS_FROM_ELSEWHERE = units.meters
 
 
-def connected_data(node: SASDataGroup, name_prefix="") -> list[NamedQuantity]:
+def connected_data(node: SASDataGroup, name_prefix="") -> dict[str, NamedQuantity]:
     """In the context of NeXus files, load a group of data entries that are organised together
     match up the units and errors with their values"""
     # Gather together data with its error terms
@@ -98,16 +99,16 @@ def connected_data(node: SASDataGroup, name_prefix="") -> list[NamedQuantity]:
 
         entries[name] = quantity
 
-    output = []
+    output = {}
 
     for name, entry in entries.items():
         if name not in uncertainties:
             if name in uncertainty_map:
                 uncertainty = entries[uncertainty_map[name]]
                 new_entry = entry.with_standard_error(uncertainty)
-                output.append(new_entry)
+                output[name] = new_entry
             else:
-                output.append(entry)
+                output[name] = entry
 
     return output
 
@@ -241,14 +242,14 @@ def parse_metadata(node : HDF5Group) -> Metadata:
 ### End Metadata parsing code
 
 
-def load_data(filename) -> list[SasData]:
+def load_data(filename) -> dict[str, SasData]:
     with h5py.File(filename, "r") as f:
         loaded_data: list[SasData] = []
 
         for root_key in f.keys():
             entry = f[root_key]
 
-            data_contents = []
+            data_contents : dict[str, NamedQuantity] = {}
 
             entry_keys = [key for key in entry if "entry" in key]
 
@@ -268,6 +269,7 @@ def load_data(filename) -> list[SasData]:
             loaded_data.append(
                 SasData(
                     name=root_key,
+                    dataset_type=one_dim,
                     data_contents=data_contents,
                     metadata=metadata,
                     verbose=False,

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -237,14 +237,8 @@ def parse_collimation(node) -> Collimation:
 
 
 def parse_instrument(raw, node) -> Instrument:
-    collimations = [
-        parse_collimation(node[x])
-        for x in node
-        if "collimation" in x
-    ]
     return Instrument(
-        raw,
-        collimations=collimations,
+        collimations= [parse_collimation(node[x]) for x in node if "collimation" in x],
         detector=[parse_detector(node[d]) for d in node if "detector" in d],
         source=parse_source(node["sassource"]),
     )

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -13,7 +13,7 @@ from h5py._hl.group import Group as HDF5Group
 
 from sasdata.data import SasData
 from sasdata.data_backing import Dataset as SASDataDataset, Group as SASDataGroup
-from sasdata.metadata import Instrument, Collimation, Aperture, Source
+from sasdata.metadata import Instrument, Collimation, Aperture, Source, BeamSize
 from sasdata.quantities.accessors import AccessorTarget
 
 from sasdata.quantities.quantity import NamedQuantity
@@ -133,6 +133,21 @@ def parse_apertures(node) -> list[Aperture]:
         result.append(Aperture(distance=distance, size=size, size_name=size_name, name=name, apType=apType))
     return result
 
+def parse_beam_size(node) -> BeamSize:
+    name = None
+    x = None
+    y = None
+    z = None
+    if "name" in node.attrs:
+        name = node.atrs["keys"]
+    if "x" in node:
+        x = node["x"]
+    if "y" in node:
+        y = node["y"]
+    if "z" in node:
+        z = node["z"]
+    return BeamSize(name=name, x=x, y=y, z=z)
+
 
 def parse_source(node) -> Source:
     beam_shape = None
@@ -151,6 +166,8 @@ def parse_source(node) -> Source:
         wavelength = node["wavelength_max"]
     if "wavelength_spread" in node:
         wavelength = node["wavelength_spread"]
+    if "beam_size" in node:
+        beam_size = parse_beam_size(node["beam_size"])
     return Source(
         radiation=node["radiation"].asstr()[0],
         beam_shape=beam_shape,

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -261,7 +261,7 @@ def load_data(filename) -> list[SasData]:
             run = [parse_string(f["sasentry01"][r]) for r in f["sasentry01"] if "run" in r]
             definition = opt_parse(f["sasentry01"], "definition", parse_string)
 
-            metadata = Metadata(AccessorTarget(SASDataGroup("root", raw_metadata),verbose=False), process=process, instrument=instrument, sample=sample, title=title, run=run, definition=definition)
+            metadata = Metadata(process=process, instrument=instrument, sample=sample, title=title, run=run, definition=definition)
 
             loaded_data.append(
                 SasData(

--- a/test/sasdataloader/reference/14250.txt
+++ b/test/sasdataloader/reference/14250.txt
@@ -1,0 +1,51 @@
+sasentry01
+  [FILE_ID_HERE/sasentry01/sasdata/I] [[0.0 ... 0.0]] ± [[0.0 ... 0.0]] cm⁻¹
+  [FILE_ID_HERE/sasentry01/sasdata/Qx] [[-0.11925 ... 0.11925000000000001]] Å⁻¹
+  [FILE_ID_HERE/sasentry01/sasdata/Qy] [[-0.11925 ... 0.11925000000000001]] Å⁻¹
+Metadata:
+
+  High C high V 63, 900oC, 10h 1.65T_SANS, Run: 14250
+  ===================================================
+
+Definition: High C high V 63, 900oC, 10h 1.65T_SANS
+Process:
+    Name: Mantid_generated_NXcanSAS
+    Date: 2016-12-06T17:15:48
+    Description: None
+    Term: None
+    Notes: None
+Sample:
+   ID:           None
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Aperture:
+  Name: None
+  Aperture size: None
+  Aperture distance: None
+Collimation:
+   Length: None
+Detector:
+   Name:         None
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         Spallation Neutron Source
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None
+Transmission Spectrum:
+    Name:             None
+    Timestamp:        None
+    Wavelengths:      None
+    Transmission:     None
+

--- a/test/sasdataloader/reference/33837.txt
+++ b/test/sasdataloader/reference/33837.txt
@@ -1,0 +1,50 @@
+sasentry01
+  [FILE_ID_HERE/sasentry01/sasdata/I] [5.416094671273121 ... 0.33697913143947616] ± [0.6152247543248875 ... 0.19365125082205084] m
+  [FILE_ID_HERE/sasentry01/sasdata/Q] [0.0041600000000000005 ... 0.6189241619415587] m
+Metadata:
+
+  MH4_5deg_16T_SLOW, Run: 33837
+  =============================
+
+Definition: MH4_5deg_16T_SLOW
+Process:
+    Name: Mantid_generated_NXcanSAS
+    Date: 11-May-2016 12:20:43
+    Description: None
+    Term: None
+    Notes: None
+Sample:
+   ID:           None
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Aperture:
+  Name: None
+  Aperture size: None
+  Aperture distance: None
+Collimation:
+   Length: None
+Detector:
+   Name:         None
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         Spallation Neutron Source
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None
+Transmission Spectrum:
+    Name:             None
+    Timestamp:        None
+    Wavelengths:      None
+    Transmission:     None
+

--- a/test/sasdataloader/reference/33837_v3.txt
+++ b/test/sasdataloader/reference/33837_v3.txt
@@ -1,0 +1,50 @@
+sasentry01
+  [FILE_ID_HERE/sasentry01/sasdata/I] [5.416094671273121 ... 0.33697913143947616] ± [0.6152247543248875 ... 0.19365125082205084] none
+  [FILE_ID_HERE/sasentry01/sasdata/Q] [0.0041600000000000005 ... 0.6189241619415587] Å⁻¹
+Metadata:
+
+  MH4_5deg_16T_SLOW, Run: 33837
+  =============================
+
+Definition: MH4_5deg_16T_SLOW
+Process:
+    Name: Mantid_generated_NXcanSAS
+    Date: 2016-07-04T10:34:34
+    Description: None
+    Term: None
+    Notes: None
+Sample:
+   ID:           None
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Aperture:
+  Name: None
+  Aperture size: None
+  Aperture distance: None
+Collimation:
+   Length: None
+Detector:
+   Name:         None
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         Spallation Neutron Source
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None
+Transmission Spectrum:
+    Name:             None
+    Timestamp:        None
+    Wavelengths:      None
+    Transmission:     None
+

--- a/test/sasdataloader/reference/BAM.txt
+++ b/test/sasdataloader/reference/BAM.txt
@@ -1,0 +1,51 @@
+sasentry01
+  [FILE_ID_HERE/sasentry01/data/I] [[-4132.585671758142 ... -4139.954861346877]] ± [[1000000000.0 ... 1000000000.0]] m⁻¹
+  [FILE_ID_HERE/sasentry01/data/Imask] [[True ... True]] m⁻¹
+  [FILE_ID_HERE/sasentry01/data/Q] [[[-0.10733919639695527 ... 0.0]]] Å⁻¹
+Metadata:
+
+  Qais oriented iron test 1, Run: 12345
+  =====================================
+
+Definition: Qais oriented iron test 1
+Process:
+    Name: None
+    Date: None
+    Description: None
+    Term: None
+    Notes: None
+Sample:
+   ID:           None
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Aperture:
+  Name: None
+  Aperture size: None
+  Aperture distance: None
+Collimation:
+   Length: None
+Detector:
+   Name:         None
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         None
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None
+Transmission Spectrum:
+    Name:             None
+    Timestamp:        None
+    Wavelengths:      None
+    Transmission:     None
+

--- a/test/sasdataloader/reference/MAR07232_rest.txt
+++ b/test/sasdataloader/reference/MAR07232_rest.txt
@@ -21,7 +21,7 @@ Sample:
 Collimation:
    Length: None
 Detector:
-   Name:         None
+   Name:         
    Distance:     None
    Offset:       None
    Orientation:  None

--- a/test/sasdataloader/reference/MAR07232_rest.txt
+++ b/test/sasdataloader/reference/MAR07232_rest.txt
@@ -12,8 +12,8 @@ Process:
     Term: None
     Notes: None
 Sample:
-   ID:           None
-   Transmission: [0.84357]
+   ID:           
+   Transmission: 0.84357
    Thickness:    None
    Temperature:  None
    Position:     None

--- a/test/sasdataloader/reference/MAR07232_rest.txt
+++ b/test/sasdataloader/reference/MAR07232_rest.txt
@@ -30,8 +30,3 @@ Source:
     Max. Wavelength:   None
     Wavelength Spread: None
     Beam Size:         None
-Transmission Spectrum:
-    Name:             None
-    Timestamp:        None
-    Wavelengths:      None
-    Transmission:     None

--- a/test/sasdataloader/reference/MAR07232_rest.txt
+++ b/test/sasdataloader/reference/MAR07232_rest.txt
@@ -1,0 +1,47 @@
+sasentry01
+Metadata:
+
+  MAR07232_rest_out.dat, Run: 2
+  =============================
+
+Definition: MAR07232_rest_out.dat
+Process:
+    Name: None
+    Date: None
+    Description: None
+    Term: None
+    Notes: None
+Sample:
+   ID:           None
+   Transmission: [0.84357]
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Aperture:
+  Name: None
+  Aperture size: None
+  Aperture distance: None
+Collimation:
+   Length: None
+Detector:
+   Name:         None
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None
+Transmission Spectrum:
+    Name:             None
+    Timestamp:        None
+    Wavelengths:      None
+    Transmission:     None

--- a/test/sasdataloader/reference/MAR07232_rest.txt
+++ b/test/sasdataloader/reference/MAR07232_rest.txt
@@ -18,10 +18,8 @@ Sample:
    Temperature:  None
    Position:     None
    Orientation:  None
-Aperture:
-  Name: None
-  Aperture size: None
-  Aperture distance: None
+Collimation:
+   Length: None
 Detector:
    Name:         None
    Distance:     None

--- a/test/sasdataloader/reference/MAR07232_rest.txt
+++ b/test/sasdataloader/reference/MAR07232_rest.txt
@@ -22,8 +22,6 @@ Aperture:
   Name: None
   Aperture size: None
   Aperture distance: None
-Collimation:
-   Length: None
 Detector:
    Name:         None
    Distance:     None

--- a/test/sasdataloader/reference/MAR07232_rest.txt
+++ b/test/sasdataloader/reference/MAR07232_rest.txt
@@ -5,12 +5,6 @@ Metadata:
   =============================
 
 Definition: MAR07232_rest_out.dat
-Process:
-    Name: None
-    Date: None
-    Description: None
-    Term: None
-    Notes: None
 Sample:
    ID:           
    Transmission: 0.84357

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
@@ -6,11 +6,10 @@ Metadata:
 
 Definition: MH4_5deg_16T_SLOW
 Process:
-    Name: None
-    Date: None
+    Name: Mantid generated CanSAS1D XML
+    Date: 11-May-2016 12:15:34
     Description: None
     Term: None
-    Notes: None
 Sample:
    ID:           
    Transmission: None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
@@ -12,7 +12,7 @@ Process:
     Term: None
     Notes: None
 Sample:
-   ID:           None
+   ID:           
    Transmission: None
    Thickness:    None
    Temperature:  None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
@@ -1,0 +1,47 @@
+sasentry01
+Metadata:
+
+  MH4_5deg_16T_SLOW, Run: 33837
+  =============================
+
+Definition: MH4_5deg_16T_SLOW
+Process:
+    Name: None
+    Date: None
+    Description: None
+    Term: None
+    Notes: None
+Sample:
+   ID:           None
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Aperture:
+  Name: None
+  Aperture size: None
+  Aperture distance: None
+Collimation:
+   Length: None
+Detector:
+   Name:         None
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         Spallation Neutron Source
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None
+Transmission Spectrum:
+    Name:             None
+    Timestamp:        None
+    Wavelengths:      None
+    Transmission:     None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
@@ -18,10 +18,8 @@ Sample:
    Temperature:  None
    Position:     None
    Orientation:  None
-Aperture:
-  Name: None
-  Aperture size: None
-  Aperture distance: None
+Collimation:
+   Length: None
 Detector:
    Name:         None
    Distance:     None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
@@ -22,8 +22,6 @@ Aperture:
   Name: None
   Aperture size: None
   Aperture distance: None
-Collimation:
-   Length: None
 Detector:
    Name:         None
    Distance:     None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
@@ -43,8 +43,3 @@ Source:
     Max. Wavelength:   None
     Wavelength Spread: None
     Beam Size:         None
-Transmission Spectrum:
-    Name:             None
-    Timestamp:        None
-    Wavelengths:      None
-    Transmission:     None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
@@ -28,6 +28,14 @@ Detector:
    Beam center:  None
    Pixel size:   None
    Slit length:  None
+Detector:
+   Name:         None
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
 Source:
     Radiation:         Spallation Neutron Source
     Shape:             None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
@@ -21,16 +21,16 @@ Sample:
 Collimation:
    Length: None
 Detector:
-   Name:         None
-   Distance:     None
+   Name:         front-detector
+   Distance:     2845.260009765625 mm
    Offset:       None
    Orientation:  None
    Beam center:  None
    Pixel size:   None
    Slit length:  None
 Detector:
-   Name:         None
-   Distance:     None
+   Name:         rear-detector
+   Distance:     4385.27978515625 mm
    Offset:       None
    Orientation:  None
    Beam center:  None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
@@ -6,11 +6,10 @@ Metadata:
 
 Definition: MH4_5deg_16T_SLOW
 Process:
-    Name: None
-    Date: None
+    Name: Mantid generated CanSAS1D XML
+    Date: 11-May-2016 12:15:34
     Description: None
     Term: None
-    Notes: None
 Sample:
    ID:           
    Transmission: None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
@@ -12,7 +12,7 @@ Process:
     Term: None
     Notes: None
 Sample:
-   ID:           None
+   ID:           
    Transmission: None
    Thickness:    None
    Temperature:  None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
@@ -43,3 +43,48 @@ Source:
     Max. Wavelength:   None
     Wavelength Spread: None
     Beam Size:         None
+sasentry02
+Metadata:
+
+  MH4_5deg_16T_SLOW, Run: 33837
+  =============================
+
+Definition: MH4_5deg_16T_SLOW
+Process:
+    Name: Mantid generated CanSAS1D XML
+    Date: 11-May-2016 12:15:34
+    Description: None
+    Term: None
+Sample:
+   ID:           
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         front-detector
+   Distance:     2845.260009765625 mm
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Detector:
+   Name:         rear-detector
+   Distance:     4385.27978515625 mm
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         Spallation Neutron Source
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
@@ -1,0 +1,47 @@
+sasentry01
+Metadata:
+
+  MH4_5deg_16T_SLOW, Run: 33837
+  =============================
+
+Definition: MH4_5deg_16T_SLOW
+Process:
+    Name: None
+    Date: None
+    Description: None
+    Term: None
+    Notes: None
+Sample:
+   ID:           None
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Aperture:
+  Name: None
+  Aperture size: None
+  Aperture distance: None
+Collimation:
+   Length: None
+Detector:
+   Name:         None
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         Spallation Neutron Source
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None
+Transmission Spectrum:
+    Name:             None
+    Timestamp:        None
+    Wavelengths:      None
+    Transmission:     None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
@@ -18,10 +18,8 @@ Sample:
    Temperature:  None
    Position:     None
    Orientation:  None
-Aperture:
-  Name: None
-  Aperture size: None
-  Aperture distance: None
+Collimation:
+   Length: None
 Detector:
    Name:         None
    Distance:     None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
@@ -22,8 +22,6 @@ Aperture:
   Name: None
   Aperture size: None
   Aperture distance: None
-Collimation:
-   Length: None
 Detector:
    Name:         None
    Distance:     None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
@@ -43,8 +43,3 @@ Source:
     Max. Wavelength:   None
     Wavelength Spread: None
     Beam Size:         None
-Transmission Spectrum:
-    Name:             None
-    Timestamp:        None
-    Wavelengths:      None
-    Transmission:     None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
@@ -28,6 +28,14 @@ Detector:
    Beam center:  None
    Pixel size:   None
    Slit length:  None
+Detector:
+   Name:         None
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
 Source:
     Radiation:         Spallation Neutron Source
     Shape:             None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
@@ -21,16 +21,16 @@ Sample:
 Collimation:
    Length: None
 Detector:
-   Name:         None
-   Distance:     None
+   Name:         front-detector
+   Distance:     2845.260009765625 mm
    Offset:       None
    Orientation:  None
    Beam center:  None
    Pixel size:   None
    Slit length:  None
 Detector:
-   Name:         None
-   Distance:     None
+   Name:         rear-detector
+   Distance:     4385.27978515625 mm
    Offset:       None
    Orientation:  None
    Beam center:  None

--- a/test/sasdataloader/reference/simpleexamplefile.txt
+++ b/test/sasdataloader/reference/simpleexamplefile.txt
@@ -18,10 +18,6 @@ Sample:
    Temperature:  None
    Position:     None
    Orientation:  None
-Aperture:
-  Name: None
-  Aperture size: None
-  Aperture distance: None
 Detector:
    Name:         None
    Distance:     None

--- a/test/sasdataloader/reference/simpleexamplefile.txt
+++ b/test/sasdataloader/reference/simpleexamplefile.txt
@@ -22,8 +22,6 @@ Aperture:
   Name: None
   Aperture size: None
   Aperture distance: None
-Collimation:
-   Length: None
 Detector:
    Name:         None
    Distance:     None

--- a/test/sasdataloader/reference/simpleexamplefile.txt
+++ b/test/sasdataloader/reference/simpleexamplefile.txt
@@ -1,0 +1,47 @@
+sasentry01
+Metadata:
+
+  None, Run: None
+  ===============
+
+Definition: None
+Process:
+    Name: None
+    Date: None
+    Description: None
+    Term: None
+    Notes: None
+Sample:
+   ID:           None
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Aperture:
+  Name: None
+  Aperture size: None
+  Aperture distance: None
+Collimation:
+   Length: None
+Detector:
+   Name:         None
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         None
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None
+Transmission Spectrum:
+    Name:             None
+    Timestamp:        None
+    Wavelengths:      None
+    Transmission:     None

--- a/test/sasdataloader/reference/x25000_no_di.txt
+++ b/test/sasdataloader/reference/x25000_no_di.txt
@@ -21,7 +21,7 @@ Sample:
 Collimation:
    Length: None
 Detector:
-   Name:         None
+   Name:         
    Distance:     None
    Offset:       None
    Orientation:  None

--- a/test/sasdataloader/reference/x25000_no_di.txt
+++ b/test/sasdataloader/reference/x25000_no_di.txt
@@ -12,7 +12,7 @@ Process:
     Term: None
     Notes: None
 Sample:
-   ID:           None
+   ID:           
    Transmission: None
    Thickness:    None
    Temperature:  None

--- a/test/sasdataloader/reference/x25000_no_di.txt
+++ b/test/sasdataloader/reference/x25000_no_di.txt
@@ -30,8 +30,3 @@ Source:
     Max. Wavelength:   None
     Wavelength Spread: None
     Beam Size:         None
-Transmission Spectrum:
-    Name:             None
-    Timestamp:        None
-    Wavelengths:      None
-    Transmission:     None

--- a/test/sasdataloader/reference/x25000_no_di.txt
+++ b/test/sasdataloader/reference/x25000_no_di.txt
@@ -5,12 +5,6 @@ Metadata:
   =======
 
 Definition: 
-Process:
-    Name: None
-    Date: None
-    Description: None
-    Term: None
-    Notes: None
 Sample:
    ID:           
    Transmission: None

--- a/test/sasdataloader/reference/x25000_no_di.txt
+++ b/test/sasdataloader/reference/x25000_no_di.txt
@@ -18,10 +18,8 @@ Sample:
    Temperature:  None
    Position:     None
    Orientation:  None
-Aperture:
-  Name: None
-  Aperture size: None
-  Aperture distance: None
+Collimation:
+   Length: None
 Detector:
    Name:         None
    Distance:     None

--- a/test/sasdataloader/reference/x25000_no_di.txt
+++ b/test/sasdataloader/reference/x25000_no_di.txt
@@ -22,8 +22,6 @@ Aperture:
   Name: None
   Aperture size: None
   Aperture distance: None
-Collimation:
-   Length: None
 Detector:
    Name:         None
    Distance:     None

--- a/test/sasdataloader/reference/x25000_no_di.txt
+++ b/test/sasdataloader/reference/x25000_no_di.txt
@@ -1,0 +1,47 @@
+sasentry01
+Metadata:
+
+  , Run: 
+  =======
+
+Definition: 
+Process:
+    Name: None
+    Date: None
+    Description: None
+    Term: None
+    Notes: None
+Sample:
+   ID:           None
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Aperture:
+  Name: None
+  Aperture size: None
+  Aperture distance: None
+Collimation:
+   Length: None
+Detector:
+   Name:         None
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None
+Transmission Spectrum:
+    Name:             None
+    Timestamp:        None
+    Wavelengths:      None
+    Transmission:     None

--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -35,7 +35,7 @@ def local_load(path: str):
     return os.path.join(os.path.dirname(__file__), path)
 
 
-@pytest.mark.current
+@pytest.mark.sasdata
 @pytest.mark.parametrize("f", test_file_names)
 def test_load_file(f):
     data = load_data(local_load(f"data/{f}.h5"))

--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -42,4 +42,4 @@ def test_load_file(f):
 
     with open(local_load(f"reference/{f}.txt")) as infile:
         expected = "".join(infile.readlines())
-    assert data[0].summary() == expected
+    assert "".join(d.summary() for d in data) == expected

--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -1,0 +1,45 @@
+"""
+Unit tests for the new recursive cansas reader
+"""
+
+import os
+import unittest
+import pytest
+import logging
+import warnings
+from io import StringIO
+
+from lxml import etree
+from lxml.etree import XMLSyntaxError
+from xml.dom import minidom
+
+from sasdata.dataloader.filereader import decode
+from sasdata.dataloader.loader import Loader
+from sasdata.dataloader.data_info import Data1D, Data2D
+from sasdata.dataloader.readers.xml_reader import XMLreader
+from sasdata.dataloader.readers.cansas_reader import Reader
+from sasdata.dataloader.readers.cansas_constants import CansasConstants
+from sasdata.temp_hdf5_reader import load_data
+
+test_file_names = [
+    "simpleexamplefile",
+    "nxcansas_1Dand2D_multisasentry",
+    "nxcansas_1Dand2D_multisasdata",
+    "MAR07232_rest",
+    "x25000_no_di",
+]
+
+
+def local_load(path: str):
+    """Get local file path"""
+    return os.path.join(os.path.dirname(__file__), path)
+
+
+@pytest.mark.current
+@pytest.mark.parametrize("f", test_file_names)
+def test_load_file(f):
+    data = load_data(local_load(f"data/{f}.h5"))
+
+    with open(local_load(f"reference/{f}.txt")) as infile:
+        expected = "".join(infile.readlines())
+    assert data[0].summary() == expected

--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -42,4 +42,5 @@ def test_load_file(f):
 
     with open(local_load(f"reference/{f}.txt")) as infile:
         expected = "".join(infile.readlines())
-    assert "".join(d.summary() for d in data) == expected
+    keys = sorted([d for d in data])
+    assert "".join(data[k].summary() for k in keys) == expected

--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -22,7 +22,7 @@ from sasdata.dataloader.readers.cansas_constants import CansasConstants
 from sasdata.temp_hdf5_reader import load_data
 
 test_file_names = [
-    "simpleexamplefile",
+    # "simpleexamplefile",
     "nxcansas_1Dand2D_multisasentry",
     "nxcansas_1Dand2D_multisasdata",
     "MAR07232_rest",


### PR DESCRIPTION
I've reworked the Metadata into a a series of dataclasses.  These dataclasses are inspired by the CANSas v1.1 standard as it is likely to be the most comprehensive of the various types of metadata that my be included.  Thus we can expect that the metadata from other formats should be a subset of the metadata for CANSas.

I've also included a unit test to check the metadata of several of the files.