### PR TITLE
Sasdata xml parser

### DIFF
--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -66,7 +66,7 @@ class SasData:
     def summary(self, indent = "  "):
         s = f"{self.name}\n"
 
-        for data in self._data_contents:
+        for data in sorted(self._data_contents, reverse=True):
             s += f"{indent}{data}\n"
 
         s += f"Metadata:\n"

--- a/sasdata/dataset_types.py
+++ b/sasdata/dataset_types.py
@@ -19,7 +19,7 @@ class DatasetType:
 one_dim = DatasetType(
             name="1D I vs Q",
             required=["Q", "I"],
-            optional=["dI", "dQ", "shadow"],
+            optional=["dI", "dQ", "Shadowfactor", "Qmean", "dQl", "dQw"],
             expected_orders=[
                 ["Q", "I", "dI"],
                 ["Q", "dQ", "I", "dI"]])
@@ -27,7 +27,7 @@ one_dim = DatasetType(
 two_dim = DatasetType(
             name="2D I vs Q",
             required=["Qx", "Qy", "I"],
-            optional=["dQx", "dQy", "dI", "Qz", "shadow"],
+            optional=["dQx", "dQy", "dI", "Qz", "ShadowFactor"],
             expected_orders=[
                 ["Qx", "Qy", "I"],
                 ["Qx", "Qy", "I", "dI"],

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -143,6 +143,7 @@ class Process:
     date :  str  | None
     description :  str  | None
     terms :  dict[str, str | Quantity[float]]
+    notes: list[str]
 
     def single_line_desc(self):
         """
@@ -156,11 +157,19 @@ class Process:
                 [f"        {k}: {v}" for k, v in self.terms.items()]) + "\n"
         else:
             termInfo = ""
+
+        if self.notes:
+            noteInfo = "    Notes:\n" + "\n".join(
+                [f"        {note}" for note in self.notes]) + "\n"
+        else:
+            noteInfo = ""
+
         return (f"Process:\n"
                 f"    Name: {self.name}\n"
                 f"    Date: {self.date}\n"
                 f"    Description: {self.description}\n"
                 f"{termInfo}"
+                f"{noteInfo}"
                 )
 
 

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -142,7 +142,7 @@ class Process:
     name :  str  | None
     date :  str  | None
     description :  str  | None
-    term :  str  | None
+    terms :  dict[str, str | Quantity[float]]
 
     def single_line_desc(self):
         """
@@ -151,11 +151,16 @@ class Process:
         return f"{self.name.value} {self.date.value} {self.description.value}"
 
     def summary(self):
+        if self.terms:
+            termInfo = "    Terms:\n" + "\n".join(
+                [f"        {k}: {v}" for k, v in self.terms.items()]) + "\n"
+        else:
+            termInfo = ""
         return (f"Process:\n"
                 f"    Name: {self.name}\n"
                 f"    Date: {self.date}\n"
                 f"    Description: {self.description}\n"
-                f"    Term: {self.term}\n"
+                f"{termInfo}"
                 )
 
 

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -184,10 +184,10 @@ class Metadata:
         run_string = self.run[0] if len(self.run) == 1 else self.run
         return (
             f"  {self.title}, Run: {run_string}\n" +
-            "  " + "="*len(self.title) +
+            "  " + "="*len(self.title if self.title else "") +
                            "=======" +
             "="*len(run_string) + "\n\n" +
             f"Definition: {self.title}\n" +
             "".join([p.summary() for p in self.process]) +
-            self.sample.summary() +
+            (self.sample.summary() if self.sample else "") +
             (self.instrument.summary() if self.instrument else ""))

--- a/sasdata/quantities/_build_tables.py
+++ b/sasdata/quantities/_build_tables.py
@@ -60,6 +60,7 @@ derived_si_units = [
 
 non_si_dimensioned_units: list[tuple[str, str | None, str, str, float, int, int, int, int, int, int, int, list]] = [
     UnitData("Ang", "Å", r"\AA", "angstrom", "angstroms", 1e-10, 1, 0, 0, 0, 0, 0, 0, []),
+    UnitData("micron", None, None, "micron", "microns", 1e-6, 1, 0, 0, 0, 0, 0, 0, []),
     UnitData("min", None, None, "minute", "minutes", 60, 0, 1, 0, 0, 0, 0, 0, []),
     UnitData("h", None, None, "hour", "hours", 360, 0, 1, 0, 0, 0, 0, 0, []),
     UnitData("d", None, None, "day", "days", 360*24, 0, 1, 0, 0, 0, 0, 0, []),

--- a/sasdata/quantities/_build_tables.py
+++ b/sasdata/quantities/_build_tables.py
@@ -108,7 +108,7 @@ aliases_2 = {
     "Ang": ["A", "Å"],
     "au": ["amu"],
     "percent": ["%"],
-    "deg": ["degr", "Deg", "degrees", "Degrees"],
+    "deg": ["degr", "Deg", "degree", "degrees", "Degrees"],
     "none": ["Counts", "counts", "cnts", "Cnts", "a.u.", "fraction", "Fraction"],
     "K": ["C"] # Ugh, cansas
 }

--- a/sasdata/quantities/accessors.py
+++ b/sasdata/quantities/accessors.py
@@ -364,6 +364,14 @@ class LengthAccessor[T](QuantityAccessor[T]):
             return quantity.in_units_of(units.angstroms)
 
     @property
+    def microns(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns)
+
+    @property
     def miles(self) -> T:
         quantity = self.quantity
         if quantity is None:
@@ -527,6 +535,14 @@ class AreaAccessor[T](QuantityAccessor[T]):
             return None
         else:
             return quantity.in_units_of(units.square_angstroms)
+
+    @property
+    def square_microns(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.square_microns)
 
     @property
     def square_miles(self) -> T:
@@ -702,6 +718,14 @@ class VolumeAccessor[T](QuantityAccessor[T]):
             return quantity.in_units_of(units.cubic_angstroms)
 
     @property
+    def cubic_microns(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.cubic_microns)
+
+    @property
     def cubic_miles(self) -> T:
         quantity = self.quantity
         if quantity is None:
@@ -865,6 +889,14 @@ class InverselengthAccessor[T](QuantityAccessor[T]):
             return None
         else:
             return quantity.in_units_of(units.per_angstrom)
+
+    @property
+    def per_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.per_micron)
 
     @property
     def per_mile(self) -> T:
@@ -1032,6 +1064,14 @@ class InverseareaAccessor[T](QuantityAccessor[T]):
             return quantity.in_units_of(units.per_square_angstrom)
 
     @property
+    def per_square_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.per_square_micron)
+
+    @property
     def per_square_mile(self) -> T:
         quantity = self.quantity
         if quantity is None:
@@ -1195,6 +1235,14 @@ class InversevolumeAccessor[T](QuantityAccessor[T]):
             return None
         else:
             return quantity.in_units_of(units.per_cubic_angstrom)
+
+    @property
+    def per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.per_cubic_micron)
 
     @property
     def per_cubic_mile(self) -> T:
@@ -2842,6 +2890,94 @@ class SpeedAccessor[T](QuantityAccessor[T]):
             return None
         else:
             return quantity.in_units_of(units.angstroms_per_year)
+
+    @property
+    def microns_per_second(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_second)
+
+    @property
+    def microns_per_millisecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_millisecond)
+
+    @property
+    def microns_per_microsecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_microsecond)
+
+    @property
+    def microns_per_nanosecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_nanosecond)
+
+    @property
+    def microns_per_picosecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_picosecond)
+
+    @property
+    def microns_per_femtosecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_femtosecond)
+
+    @property
+    def microns_per_attosecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_attosecond)
+
+    @property
+    def microns_per_minute(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_minute)
+
+    @property
+    def microns_per_hour(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_hour)
+
+    @property
+    def microns_per_day(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_day)
+
+    @property
+    def microns_per_year(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_year)
 
     @property
     def miles_per_second(self) -> T:
@@ -4607,6 +4743,94 @@ class AccelerationAccessor[T](QuantityAccessor[T]):
             return None
         else:
             return quantity.in_units_of(units.angstroms_per_square_year)
+
+    @property
+    def microns_per_square_second(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_square_second)
+
+    @property
+    def microns_per_square_millisecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_square_millisecond)
+
+    @property
+    def microns_per_square_microsecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_square_microsecond)
+
+    @property
+    def microns_per_square_nanosecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_square_nanosecond)
+
+    @property
+    def microns_per_square_picosecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_square_picosecond)
+
+    @property
+    def microns_per_square_femtosecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_square_femtosecond)
+
+    @property
+    def microns_per_square_attosecond(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_square_attosecond)
+
+    @property
+    def microns_per_square_minute(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_square_minute)
+
+    @property
+    def microns_per_square_hour(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_square_hour)
+
+    @property
+    def microns_per_square_day(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_square_day)
+
+    @property
+    def microns_per_square_year(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.microns_per_square_year)
 
     @property
     def miles_per_square_second(self) -> T:
@@ -7012,6 +7236,134 @@ class DensityAccessor[T](QuantityAccessor[T]):
             return None
         else:
             return quantity.in_units_of(units.ounces_per_cubic_angstrom)
+
+    @property
+    def grams_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.grams_per_cubic_micron)
+
+    @property
+    def exagrams_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.exagrams_per_cubic_micron)
+
+    @property
+    def petagrams_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.petagrams_per_cubic_micron)
+
+    @property
+    def teragrams_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.teragrams_per_cubic_micron)
+
+    @property
+    def gigagrams_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.gigagrams_per_cubic_micron)
+
+    @property
+    def megagrams_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.megagrams_per_cubic_micron)
+
+    @property
+    def kilograms_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.kilograms_per_cubic_micron)
+
+    @property
+    def milligrams_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.milligrams_per_cubic_micron)
+
+    @property
+    def micrograms_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.micrograms_per_cubic_micron)
+
+    @property
+    def nanograms_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.nanograms_per_cubic_micron)
+
+    @property
+    def picograms_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.picograms_per_cubic_micron)
+
+    @property
+    def femtograms_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.femtograms_per_cubic_micron)
+
+    @property
+    def attograms_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.attograms_per_cubic_micron)
+
+    @property
+    def atomic_mass_units_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.atomic_mass_units_per_cubic_micron)
+
+    @property
+    def pounds_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.pounds_per_cubic_micron)
+
+    @property
+    def ounces_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.ounces_per_cubic_micron)
 
     @property
     def grams_per_cubic_mile(self) -> T:
@@ -10094,6 +10446,62 @@ class ConcentrationAccessor[T](QuantityAccessor[T]):
             return None
         else:
             return quantity.in_units_of(units.attomoles_per_cubic_angstrom)
+
+    @property
+    def moles_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.moles_per_cubic_micron)
+
+    @property
+    def millimoles_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.millimoles_per_cubic_micron)
+
+    @property
+    def micromoles_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.micromoles_per_cubic_micron)
+
+    @property
+    def nanomoles_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.nanomoles_per_cubic_micron)
+
+    @property
+    def picomoles_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.picomoles_per_cubic_micron)
+
+    @property
+    def femtomoles_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.femtomoles_per_cubic_micron)
+
+    @property
+    def attomoles_per_cubic_micron(self) -> T:
+        quantity = self.quantity
+        if quantity is None:
+            return None
+        else:
+            return quantity.in_units_of(units.attomoles_per_cubic_micron)
 
     @property
     def moles_per_cubic_mile(self) -> T:

--- a/sasdata/quantities/units.py
+++ b/sasdata/quantities/units.py
@@ -681,6 +681,7 @@ picohenry = NamedUnit(1e-12, Dimensions(2, -2, 1, -2, 0, 0, 0),name='picohenry',
 femtohenry = NamedUnit(1e-15, Dimensions(2, -2, 1, -2, 0, 0, 0),name='femtohenry',ascii_symbol='fH',symbol='fH')
 attohenry = NamedUnit(1e-18, Dimensions(2, -2, 1, -2, 0, 0, 0),name='attohenry',ascii_symbol='aH',symbol='aH')
 angstroms = NamedUnit(1e-10, Dimensions(1, 0, 0, 0, 0, 0, 0),name='angstroms',ascii_symbol='Ang',latex_symbol=r'\AA',symbol='Å')
+microns = NamedUnit(1e-06, Dimensions(1, 0, 0, 0, 0, 0, 0),name='microns',ascii_symbol='micron',symbol='micron')
 minutes = NamedUnit(60, Dimensions(0, 1, 0, 0, 0, 0, 0),name='minutes',ascii_symbol='min',symbol='min')
 hours = NamedUnit(360, Dimensions(0, 1, 0, 0, 0, 0, 0),name='hours',ascii_symbol='h',symbol='h')
 days = NamedUnit(8640, Dimensions(0, 1, 0, 0, 0, 0, 0),name='days',ascii_symbol='d',symbol='d')
@@ -802,6 +803,11 @@ cubic_angstroms = NamedUnit(1e-30, Dimensions(length=3), name='cubic_angstroms',
 per_angstrom = NamedUnit(10000000000.0, Dimensions(length=-1), name='per_angstrom', ascii_symbol='Ang^-1', symbol='Å⁻¹')
 per_square_angstrom = NamedUnit(1e+20, Dimensions(length=-2), name='per_square_angstrom', ascii_symbol='Ang^-2', symbol='Å⁻²')
 per_cubic_angstrom = NamedUnit(9.999999999999999e+29, Dimensions(length=-3), name='per_cubic_angstrom', ascii_symbol='Ang^-3', symbol='Å⁻³')
+square_microns = NamedUnit(1e-12, Dimensions(length=2), name='square_microns', ascii_symbol='micron^2', symbol='micron²')
+cubic_microns = NamedUnit(9.999999999999999e-19, Dimensions(length=3), name='cubic_microns', ascii_symbol='micron^3', symbol='micron³')
+per_micron = NamedUnit(1000000.0, Dimensions(length=-1), name='per_micron', ascii_symbol='micron^-1', symbol='micron⁻¹')
+per_square_micron = NamedUnit(1000000000000.0001, Dimensions(length=-2), name='per_square_micron', ascii_symbol='micron^-2', symbol='micron⁻²')
+per_cubic_micron = NamedUnit(1.0000000000000001e+18, Dimensions(length=-3), name='per_cubic_micron', ascii_symbol='micron^-3', symbol='micron⁻³')
 square_miles = NamedUnit(2589988.110336, Dimensions(length=2), name='square_miles', ascii_symbol='miles^2', symbol='miles²')
 cubic_miles = NamedUnit(4168181825.44058, Dimensions(length=3), name='cubic_miles', ascii_symbol='miles^3', symbol='miles³')
 per_mile = NamedUnit(0.0006213711922373339, Dimensions(length=-1), name='per_mile', ascii_symbol='miles^-1', symbol='miles⁻¹')
@@ -1174,6 +1180,28 @@ angstroms_per_day = NamedUnit(1.1574074074074074e-14, Dimensions(length=1, time=
 angstroms_per_square_day = NamedUnit(1.3395919067215363e-18, Dimensions(length=1, time=-2), name='angstroms_per_square_day', ascii_symbol='Ang/d^2', symbol='Åd⁻²')
 angstroms_per_year = NamedUnit(3.168873850681143e-17, Dimensions(length=1, time=-1), name='angstroms_per_year', ascii_symbol='Ang/y', symbol='Åy⁻¹')
 angstroms_per_square_year = NamedUnit(1.0041761481530734e-23, Dimensions(length=1, time=-2), name='angstroms_per_square_year', ascii_symbol='Ang/y^2', symbol='Åy⁻²')
+microns_per_second = NamedUnit(1e-06, Dimensions(length=1, time=-1), name='microns_per_second', ascii_symbol='micron/s', symbol='microns⁻¹')
+microns_per_square_second = NamedUnit(1e-06, Dimensions(length=1, time=-2), name='microns_per_square_second', ascii_symbol='micron/s^2', symbol='microns⁻²')
+microns_per_millisecond = NamedUnit(0.001, Dimensions(length=1, time=-1), name='microns_per_millisecond', ascii_symbol='micron/ms', symbol='micronms⁻¹')
+microns_per_square_millisecond = NamedUnit(1.0, Dimensions(length=1, time=-2), name='microns_per_square_millisecond', ascii_symbol='micron/ms^2', symbol='micronms⁻²')
+microns_per_microsecond = NamedUnit(1.0, Dimensions(length=1, time=-1), name='microns_per_microsecond', ascii_symbol='micron/us', symbol='micronµs⁻¹')
+microns_per_square_microsecond = NamedUnit(1000000.0, Dimensions(length=1, time=-2), name='microns_per_square_microsecond', ascii_symbol='micron/us^2', symbol='micronµs⁻²')
+microns_per_nanosecond = NamedUnit(999.9999999999999, Dimensions(length=1, time=-1), name='microns_per_nanosecond', ascii_symbol='micron/ns', symbol='micronns⁻¹')
+microns_per_square_nanosecond = NamedUnit(999999999999.9999, Dimensions(length=1, time=-2), name='microns_per_square_nanosecond', ascii_symbol='micron/ns^2', symbol='micronns⁻²')
+microns_per_picosecond = NamedUnit(1000000.0, Dimensions(length=1, time=-1), name='microns_per_picosecond', ascii_symbol='micron/ps', symbol='micronps⁻¹')
+microns_per_square_picosecond = NamedUnit(1e+18, Dimensions(length=1, time=-2), name='microns_per_square_picosecond', ascii_symbol='micron/ps^2', symbol='micronps⁻²')
+microns_per_femtosecond = NamedUnit(999999999.9999999, Dimensions(length=1, time=-1), name='microns_per_femtosecond', ascii_symbol='micron/fs', symbol='micronfs⁻¹')
+microns_per_square_femtosecond = NamedUnit(9.999999999999998e+23, Dimensions(length=1, time=-2), name='microns_per_square_femtosecond', ascii_symbol='micron/fs^2', symbol='micronfs⁻²')
+microns_per_attosecond = NamedUnit(999999999999.9999, Dimensions(length=1, time=-1), name='microns_per_attosecond', ascii_symbol='micron/as', symbol='micronas⁻¹')
+microns_per_square_attosecond = NamedUnit(9.999999999999999e+29, Dimensions(length=1, time=-2), name='microns_per_square_attosecond', ascii_symbol='micron/as^2', symbol='micronas⁻²')
+microns_per_minute = NamedUnit(1.6666666666666667e-08, Dimensions(length=1, time=-1), name='microns_per_minute', ascii_symbol='micron/min', symbol='micronmin⁻¹')
+microns_per_square_minute = NamedUnit(2.7777777777777777e-10, Dimensions(length=1, time=-2), name='microns_per_square_minute', ascii_symbol='micron/min^2', symbol='micronmin⁻²')
+microns_per_hour = NamedUnit(2.7777777777777776e-09, Dimensions(length=1, time=-1), name='microns_per_hour', ascii_symbol='micron/h', symbol='micronh⁻¹')
+microns_per_square_hour = NamedUnit(7.716049382716049e-12, Dimensions(length=1, time=-2), name='microns_per_square_hour', ascii_symbol='micron/h^2', symbol='micronh⁻²')
+microns_per_day = NamedUnit(1.1574074074074074e-10, Dimensions(length=1, time=-1), name='microns_per_day', ascii_symbol='micron/d', symbol='micrond⁻¹')
+microns_per_square_day = NamedUnit(1.3395919067215363e-14, Dimensions(length=1, time=-2), name='microns_per_square_day', ascii_symbol='micron/d^2', symbol='micrond⁻²')
+microns_per_year = NamedUnit(3.168873850681143e-13, Dimensions(length=1, time=-1), name='microns_per_year', ascii_symbol='micron/y', symbol='microny⁻¹')
+microns_per_square_year = NamedUnit(1.0041761481530734e-19, Dimensions(length=1, time=-2), name='microns_per_square_year', ascii_symbol='micron/y^2', symbol='microny⁻²')
 miles_per_second = NamedUnit(1609.344, Dimensions(length=1, time=-1), name='miles_per_second', ascii_symbol='miles/s', symbol='miless⁻¹')
 miles_per_square_second = NamedUnit(1609.344, Dimensions(length=1, time=-2), name='miles_per_square_second', ascii_symbol='miles/s^2', symbol='miless⁻²')
 miles_per_millisecond = NamedUnit(1609344.0, Dimensions(length=1, time=-1), name='miles_per_millisecond', ascii_symbol='miles/ms', symbol='milesms⁻¹')
@@ -1518,6 +1546,22 @@ attograms_per_cubic_angstrom = NamedUnit(1000000000.0, Dimensions(length=-3, mas
 atomic_mass_units_per_cubic_angstrom = NamedUnit(1660.5389209999996, Dimensions(length=-3, mass=1), name='atomic_mass_units_per_cubic_angstrom', ascii_symbol='au Ang^-3', symbol='auÅ⁻³')
 pounds_per_cubic_angstrom = NamedUnit(4.5359237e+29, Dimensions(length=-3, mass=1), name='pounds_per_cubic_angstrom', ascii_symbol='lb Ang^-3', symbol='lbÅ⁻³')
 ounces_per_cubic_angstrom = NamedUnit(2.8349523125e+28, Dimensions(length=-3, mass=1), name='ounces_per_cubic_angstrom', ascii_symbol='oz Ang^-3', symbol='ozÅ⁻³')
+grams_per_cubic_micron = NamedUnit(1000000000000000.1, Dimensions(length=-3, mass=1), name='grams_per_cubic_micron', ascii_symbol='g micron^-3', symbol='gmicron⁻³')
+exagrams_per_cubic_micron = NamedUnit(1.0000000000000001e+33, Dimensions(length=-3, mass=1), name='exagrams_per_cubic_micron', ascii_symbol='Eg micron^-3', symbol='Egmicron⁻³')
+petagrams_per_cubic_micron = NamedUnit(1.0000000000000002e+30, Dimensions(length=-3, mass=1), name='petagrams_per_cubic_micron', ascii_symbol='Pg micron^-3', symbol='Pgmicron⁻³')
+teragrams_per_cubic_micron = NamedUnit(1.0000000000000002e+27, Dimensions(length=-3, mass=1), name='teragrams_per_cubic_micron', ascii_symbol='Tg micron^-3', symbol='Tgmicron⁻³')
+gigagrams_per_cubic_micron = NamedUnit(1.0000000000000001e+24, Dimensions(length=-3, mass=1), name='gigagrams_per_cubic_micron', ascii_symbol='Gg micron^-3', symbol='Ggmicron⁻³')
+megagrams_per_cubic_micron = NamedUnit(1.0000000000000001e+21, Dimensions(length=-3, mass=1), name='megagrams_per_cubic_micron', ascii_symbol='Mg micron^-3', symbol='Mgmicron⁻³')
+kilograms_per_cubic_micron = NamedUnit(1.0000000000000001e+18, Dimensions(length=-3, mass=1), name='kilograms_per_cubic_micron', ascii_symbol='kg micron^-3', symbol='kgmicron⁻³')
+milligrams_per_cubic_micron = NamedUnit(1000000000000.0001, Dimensions(length=-3, mass=1), name='milligrams_per_cubic_micron', ascii_symbol='mg micron^-3', symbol='mgmicron⁻³')
+micrograms_per_cubic_micron = NamedUnit(1000000000.0000002, Dimensions(length=-3, mass=1), name='micrograms_per_cubic_micron', ascii_symbol='ug micron^-3', symbol='µgmicron⁻³')
+nanograms_per_cubic_micron = NamedUnit(1000000.0000000003, Dimensions(length=-3, mass=1), name='nanograms_per_cubic_micron', ascii_symbol='ng micron^-3', symbol='ngmicron⁻³')
+picograms_per_cubic_micron = NamedUnit(1000.0000000000002, Dimensions(length=-3, mass=1), name='picograms_per_cubic_micron', ascii_symbol='pg micron^-3', symbol='pgmicron⁻³')
+femtograms_per_cubic_micron = NamedUnit(1.0000000000000002, Dimensions(length=-3, mass=1), name='femtograms_per_cubic_micron', ascii_symbol='fg micron^-3', symbol='fgmicron⁻³')
+attograms_per_cubic_micron = NamedUnit(0.0010000000000000002, Dimensions(length=-3, mass=1), name='attograms_per_cubic_micron', ascii_symbol='ag micron^-3', symbol='agmicron⁻³')
+atomic_mass_units_per_cubic_micron = NamedUnit(1.660538921e-09, Dimensions(length=-3, mass=1), name='atomic_mass_units_per_cubic_micron', ascii_symbol='au micron^-3', symbol='aumicron⁻³')
+pounds_per_cubic_micron = NamedUnit(4.5359237000000006e+17, Dimensions(length=-3, mass=1), name='pounds_per_cubic_micron', ascii_symbol='lb micron^-3', symbol='lbmicron⁻³')
+ounces_per_cubic_micron = NamedUnit(2.8349523125000004e+16, Dimensions(length=-3, mass=1), name='ounces_per_cubic_micron', ascii_symbol='oz micron^-3', symbol='ozmicron⁻³')
 grams_per_cubic_mile = NamedUnit(2.399127585789277e-13, Dimensions(length=-3, mass=1), name='grams_per_cubic_mile', ascii_symbol='g miles^-3', symbol='gmiles⁻³')
 exagrams_per_cubic_mile = NamedUnit(239912.7585789277, Dimensions(length=-3, mass=1), name='exagrams_per_cubic_mile', ascii_symbol='Eg miles^-3', symbol='Egmiles⁻³')
 petagrams_per_cubic_mile = NamedUnit(239.9127585789277, Dimensions(length=-3, mass=1), name='petagrams_per_cubic_mile', ascii_symbol='Pg miles^-3', symbol='Pgmiles⁻³')
@@ -1694,6 +1738,13 @@ nanomoles_per_cubic_angstrom = NamedUnit(6.02214076e+44, Dimensions(length=-3, m
 picomoles_per_cubic_angstrom = NamedUnit(6.02214076e+41, Dimensions(length=-3, moles_hint=1), name='picomoles_per_cubic_angstrom', ascii_symbol='pmol Ang^-3', symbol='pmolÅ⁻³')
 femtomoles_per_cubic_angstrom = NamedUnit(6.022140759999999e+38, Dimensions(length=-3, moles_hint=1), name='femtomoles_per_cubic_angstrom', ascii_symbol='fmol Ang^-3', symbol='fmolÅ⁻³')
 attomoles_per_cubic_angstrom = NamedUnit(6.02214076e+35, Dimensions(length=-3, moles_hint=1), name='attomoles_per_cubic_angstrom', ascii_symbol='amol Ang^-3', symbol='amolÅ⁻³')
+moles_per_cubic_micron = NamedUnit(6.022140760000001e+41, Dimensions(length=-3, moles_hint=1), name='moles_per_cubic_micron', ascii_symbol='mol micron^-3', symbol='molmicron⁻³')
+millimoles_per_cubic_micron = NamedUnit(6.022140760000001e+38, Dimensions(length=-3, moles_hint=1), name='millimoles_per_cubic_micron', ascii_symbol='mmol micron^-3', symbol='mmolmicron⁻³')
+micromoles_per_cubic_micron = NamedUnit(6.0221407600000004e+35, Dimensions(length=-3, moles_hint=1), name='micromoles_per_cubic_micron', ascii_symbol='umol micron^-3', symbol='µmolmicron⁻³')
+nanomoles_per_cubic_micron = NamedUnit(6.022140760000001e+32, Dimensions(length=-3, moles_hint=1), name='nanomoles_per_cubic_micron', ascii_symbol='nmol micron^-3', symbol='nmolmicron⁻³')
+picomoles_per_cubic_micron = NamedUnit(6.022140760000001e+29, Dimensions(length=-3, moles_hint=1), name='picomoles_per_cubic_micron', ascii_symbol='pmol micron^-3', symbol='pmolmicron⁻³')
+femtomoles_per_cubic_micron = NamedUnit(6.022140760000001e+26, Dimensions(length=-3, moles_hint=1), name='femtomoles_per_cubic_micron', ascii_symbol='fmol micron^-3', symbol='fmolmicron⁻³')
+attomoles_per_cubic_micron = NamedUnit(6.0221407600000005e+23, Dimensions(length=-3, moles_hint=1), name='attomoles_per_cubic_micron', ascii_symbol='amol micron^-3', symbol='amolmicron⁻³')
 moles_per_cubic_mile = NamedUnit(144478840228220.0, Dimensions(length=-3, moles_hint=1), name='moles_per_cubic_mile', ascii_symbol='mol miles^-3', symbol='molmiles⁻³')
 millimoles_per_cubic_mile = NamedUnit(144478840228.22003, Dimensions(length=-3, moles_hint=1), name='millimoles_per_cubic_mile', ascii_symbol='mmol miles^-3', symbol='mmolmiles⁻³')
 micromoles_per_cubic_mile = NamedUnit(144478840.22822002, Dimensions(length=-3, moles_hint=1), name='micromoles_per_cubic_mile', ascii_symbol='umol miles^-3', symbol='µmolmiles⁻³')
@@ -1990,6 +2041,7 @@ symbol_lookup = {
         "aH": attohenry,
         "Ang": angstroms,
         "Å": angstroms,
+        "micron": microns,
         "min": minutes,
         "h": hours,
         "d": days,
@@ -2081,6 +2133,7 @@ length = UnitGroup(
     decimeters,
     centimeters,
     angstroms,
+    microns,
     miles,
     yards,
     feet,
@@ -2106,6 +2159,7 @@ area = UnitGroup(
     square_decimeters,
     square_centimeters,
     square_angstroms,
+    square_microns,
     square_miles,
     square_yards,
     square_feet,
@@ -2132,6 +2186,7 @@ volume = UnitGroup(
     cubic_decimeters,
     cubic_centimeters,
     cubic_angstroms,
+    cubic_microns,
     cubic_miles,
     cubic_yards,
     cubic_feet,
@@ -2157,6 +2212,7 @@ inverse_length = UnitGroup(
     per_decimeter,
     per_centimeter,
     per_angstrom,
+    per_micron,
     per_mile,
     per_yard,
     per_foot,
@@ -2182,6 +2238,7 @@ inverse_area = UnitGroup(
     per_square_decimeter,
     per_square_centimeter,
     per_square_angstrom,
+    per_square_micron,
     per_square_mile,
     per_square_yard,
     per_square_foot,
@@ -2207,6 +2264,7 @@ inverse_volume = UnitGroup(
     per_cubic_decimeter,
     per_cubic_centimeter,
     per_cubic_angstrom,
+    per_cubic_micron,
     per_cubic_mile,
     per_cubic_yard,
     per_cubic_foot,
@@ -2426,6 +2484,17 @@ speed = UnitGroup(
     angstroms_per_hour,
     angstroms_per_day,
     angstroms_per_year,
+    microns_per_second,
+    microns_per_millisecond,
+    microns_per_microsecond,
+    microns_per_nanosecond,
+    microns_per_picosecond,
+    microns_per_femtosecond,
+    microns_per_attosecond,
+    microns_per_minute,
+    microns_per_hour,
+    microns_per_day,
+    microns_per_year,
     miles_per_second,
     miles_per_millisecond,
     miles_per_microsecond,
@@ -2651,6 +2720,17 @@ acceleration = UnitGroup(
     angstroms_per_square_hour,
     angstroms_per_square_day,
     angstroms_per_square_year,
+    microns_per_square_second,
+    microns_per_square_millisecond,
+    microns_per_square_microsecond,
+    microns_per_square_nanosecond,
+    microns_per_square_picosecond,
+    microns_per_square_femtosecond,
+    microns_per_square_attosecond,
+    microns_per_square_minute,
+    microns_per_square_hour,
+    microns_per_square_day,
+    microns_per_square_year,
     miles_per_square_second,
     miles_per_square_millisecond,
     miles_per_square_microsecond,
@@ -2956,6 +3036,22 @@ density = UnitGroup(
     atomic_mass_units_per_cubic_angstrom,
     pounds_per_cubic_angstrom,
     ounces_per_cubic_angstrom,
+    grams_per_cubic_micron,
+    exagrams_per_cubic_micron,
+    petagrams_per_cubic_micron,
+    teragrams_per_cubic_micron,
+    gigagrams_per_cubic_micron,
+    megagrams_per_cubic_micron,
+    kilograms_per_cubic_micron,
+    milligrams_per_cubic_micron,
+    micrograms_per_cubic_micron,
+    nanograms_per_cubic_micron,
+    picograms_per_cubic_micron,
+    femtograms_per_cubic_micron,
+    attograms_per_cubic_micron,
+    atomic_mass_units_per_cubic_micron,
+    pounds_per_cubic_micron,
+    ounces_per_cubic_micron,
     grams_per_cubic_mile,
     exagrams_per_cubic_mile,
     petagrams_per_cubic_mile,
@@ -3420,6 +3516,13 @@ concentration = UnitGroup(
     picomoles_per_cubic_angstrom,
     femtomoles_per_cubic_angstrom,
     attomoles_per_cubic_angstrom,
+    moles_per_cubic_micron,
+    millimoles_per_cubic_micron,
+    micromoles_per_cubic_micron,
+    nanomoles_per_cubic_micron,
+    picomoles_per_cubic_micron,
+    femtomoles_per_cubic_micron,
+    attomoles_per_cubic_micron,
     moles_per_cubic_mile,
     millimoles_per_cubic_mile,
     micromoles_per_cubic_mile,

--- a/sasdata/quantities/units.py
+++ b/sasdata/quantities/units.py
@@ -2044,6 +2044,7 @@ symbol_lookup = {
         "amu": atomic_mass_units,
         "degr": degrees,
         "Deg": degrees,
+        "degree": degrees,
         "degrees": degrees,
         "Degrees": degrees,
         "Counts": none,

--- a/sasdata/quantities/units.py
+++ b/sasdata/quantities/units.py
@@ -379,7 +379,7 @@ class NamedUnit(Unit):
         """Match other units exactly or match strings against ANY of our names"""
         match other:
             case str():
-                return self.name == other or self.ascii_symbol == other or self.symbol == other
+                return self.name == other or self.name == f"{other}s" or self.ascii_symbol == other or self.symbol == other
             case NamedUnit():
                 return self.name == other.name \
                     and self.ascii_symbol == other.ascii_symbol and self.symbol == other.symbol

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -274,7 +274,7 @@ def parse_metadata(node : HDF5Group) -> Metadata:
 ### End Metadata parsing code
 
 
-def load_data(filename) -> dict[str, SasData]:
+def load_data(filename: str) -> dict[str, SasData]:
     with h5py.File(filename, "r") as f:
         loaded_data: dict[str, SasData] = {}
 

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -254,7 +254,8 @@ def parse_process(node : HDF5Group) -> Process:
     description = opt_parse(node, "description", parse_string)
     term_values = [parse_term(node[n]) for n in node if "term" in n]
     terms = {tup[0]: tup[1] for tup in term_values if tup is not None}
-    return Process(name=name, date=date, description=description, terms=terms)
+    notes = [parse_string(node[n]) for n in node if "note" in n]
+    return Process(name=name, date=date, description=description, terms=terms, notes=notes)
 
 def parse_metadata(node : HDF5Group) -> Metadata:
     instrument = opt_parse(node, "sasinstrument", parse_instrument)

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -242,7 +242,7 @@ def parse_process(node : HDF5Group) -> Process:
     date = opt_parse(node, "date", parse_string)
     description = opt_parse(node, "description", parse_string)
     term = opt_parse(node, "term", parse_string)
-    return Process(name=name, date=date, description=description, term=term)
+    return Process(name=name, date=date, description=description, terms=term)
 
 def parse_metadata(node : HDF5Group) -> Metadata:
     instrument = opt_parse(node, "sasinstrument", parse_instrument)

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -151,7 +151,6 @@ def parse_apterture(node : HDF5Group) -> Aperture:
     return Aperture(distance=distance, size=size, size_name=size_name, name=name, type_=type_)
 
 def parse_beam_size(node : HDF5Group) -> BeamSize:
-    name = None
     name = attr_parse(node, "name")
     size = parse_vec3(node)
     return BeamSize(name=name, size=size)

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -268,11 +268,16 @@ def load_data(filename) -> dict[str, SasData]:
     for entry in tree.getroot().findall(f"{version}:SASentry", ns):
         name = attr_parse(entry, "name")
 
+        title = opt_parse(entry, "Title", version, parse_string)
+
         if name is None:
-            name = f"SasData{dataindex:02}"
+            if title is None:
+                name = f"SasData{dataindex:02}"
+            else:
+                name = title
 
         metadata = Metadata(
-            title=opt_parse(entry, "Title", version, parse_string),
+            title=title,
             run=all_parse(entry, "Run", version, parse_string),
             instrument=opt_parse(entry, "SASinstrument", version, parse_instrument),
             process=all_parse(entry, "SASprocess", version, parse_process),

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -124,21 +124,14 @@ def parse_beam_size(node: etree._Element, version: str) -> BeamSize:
 
 def parse_source(node: etree._Element, version: str) -> Source:
     """Parse a radiation source"""
-    radiation = opt_parse(node, "radiation", version, parse_string)
-    beam_shape = opt_parse(node, "beam_shape", version, parse_string)
-    beam_size = opt_parse(node, "beam_size", version, parse_beam_size)
-    wavelength = opt_parse(node, "wavelength", version, parse_quantity)
-    wavelength_min = opt_parse(node, "wavelength_min", version, parse_quantity)
-    wavelength_max = opt_parse(node, "wavelength_max", version, parse_quantity)
-    wavelength_spread = opt_parse(node, "wavelength_spread", version, parse_quantity)
     return Source(
-        radiation=radiation,
-        beam_size=beam_size,
-        beam_shape=beam_shape,
-        wavelength=wavelength,
-        wavelength_min=wavelength_min,
-        wavelength_max=wavelength_max,
-        wavelength_spread=wavelength_spread,
+        radiation=opt_parse(node, "radiation", version, parse_string)
+        beam_size=opt_parse(node, "beam_size", version, parse_string)
+        beam_shape=opt_parse(node, "beam_shape", version, parse_beam_size)
+        wavelength=opt_parse(node, "wavelength", version, parse_quantity)
+        wavelength_min=opt_parse(node, "wavelength_min", version, parse_quantity)
+        wavelength_max=opt_parse(node, "wavelength_max", version, parse_quantity)
+        wavelength_spread=opt_parse(node, "wavelength_spread", version, parse_quantity)
     )
 
 

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -112,7 +112,9 @@ def parse_process(node: etree._Element, version: str) -> Process:
         t.attrib["name"]: parse_term(t, version)
         for t in node.findall(f"{version}:term", ns)
     }
-    return Process(name=name, date=date, description=description, terms=terms)
+    notes = [parse_string(note, version) for note in node.findall(f"{version}:SASprocessnote", ns)]
+    notes = [n.strip() for n in notes if n is not None and n.strip()]
+    return Process(name=name, date=date, description=description, terms=terms, notes=notes)
 
 
 def parse_beam_size(node: etree._Element, version: str) -> BeamSize:

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -252,7 +252,7 @@ def get_cansas_version(root) -> str | None:
     return None
 
 
-def load_data(filename) -> dict[str, SasData]:
+def load_data(filename: str) -> dict[str, SasData]:
     """Load scattering data from an XML file"""
     loaded_data: dict[str, SasData] = {}
     tree = etree.parse(filename)

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -259,11 +259,17 @@ def load_data(filename) -> dict[str, SasData]:
     version = get_cansas_version(root)
 
     if version is None:
-        logger.error(f"Invalid root: {root.tag}")
+        logger.error(f"Invalid root: {root.tag!r}")
         return loaded_data
+
+    # How many data sets have we loaded?
+    dataindex = 1
 
     for entry in tree.getroot().findall(f"{version}:SASentry", ns):
         name = attr_parse(entry, "name")
+
+        if name is None:
+            name = f"SasData{dataindex:02}"
 
         metadata = Metadata(
             title=opt_parse(entry, "Title", version, parse_string),
@@ -290,6 +296,7 @@ def load_data(filename) -> dict[str, SasData]:
             metadata=metadata,
             verbose=False,
         )
+        dataindex += 1
     return loaded_data
 
 

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -152,7 +152,7 @@ def parse_aperture(node: etree._Element, version: str) -> Aperture:
     """Parse an aperture description"""
     size = opt_parse(node, "size", version, parse_vec3)
     if size and (innerSize := node.find(f"{version}:size", ns)) is not None:
-            size_name = attr_parse(innerSize, "name")
+        size_name = attr_parse(innerSize, "name")
     else:
         size_name = None
     return Aperture(

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -96,16 +96,23 @@ def parse_rot3(node: etree._Element, version: str) -> Rot3:
     return Rot3(roll=roll, pitch=pitch, yaw=yaw)
 
 
+def parse_term(node: etree._Element, version: str) -> str | Quantity[float]:
+    """Parse a process term, which may be a measured quantity or a string"""
+    if "unit" in node.attrib:
+        return parse_quantity(node, version)
+    else:
+        return parse_string(node, version)
+
 def parse_process(node: etree._Element, version: str) -> Process:
     """Parse an experimental process"""
     name = opt_parse(node, "name", version, parse_string)
     date = opt_parse(node, "date", version, parse_string)
     description = opt_parse(node, "description", version, parse_string)
     terms = {
-        t.attrib["name"]: parse_string(t, version)
+        t.attrib["name"]: parse_term(t, version)
         for t in node.findall(f"{version}:term", ns)
     }
-    return Process(name=name, date=date, description=description, term=terms)
+    return Process(name=name, date=date, description=description, terms=terms)
 
 
 def parse_beam_size(node: etree._Element, version: str) -> BeamSize:

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -125,13 +125,13 @@ def parse_beam_size(node: etree._Element, version: str) -> BeamSize:
 def parse_source(node: etree._Element, version: str) -> Source:
     """Parse a radiation source"""
     return Source(
-        radiation=opt_parse(node, "radiation", version, parse_string)
-        beam_size=opt_parse(node, "beam_size", version, parse_string)
-        beam_shape=opt_parse(node, "beam_shape", version, parse_beam_size)
-        wavelength=opt_parse(node, "wavelength", version, parse_quantity)
-        wavelength_min=opt_parse(node, "wavelength_min", version, parse_quantity)
-        wavelength_max=opt_parse(node, "wavelength_max", version, parse_quantity)
-        wavelength_spread=opt_parse(node, "wavelength_spread", version, parse_quantity)
+        radiation=opt_parse(node, "radiation", version, parse_string),
+        beam_size=opt_parse(node, "beam_size", version, parse_beam_size),
+        beam_shape=opt_parse(node, "beam_shape", version, parse_string),
+        wavelength=opt_parse(node, "wavelength", version, parse_quantity),
+        wavelength_min=opt_parse(node, "wavelength_min", version, parse_quantity),
+        wavelength_max=opt_parse(node, "wavelength_max", version, parse_quantity),
+        wavelength_spread=opt_parse(node, "wavelength_spread", version, parse_quantity),
     )
 
 

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -217,7 +217,7 @@ def parse_data(node: etree.Element, version: str) -> dict[str, Quantity]:
             keys.add(name)
         aos.append(struct)
 
-    # Convert array of structures to strucgture of arrays
+    # Convert array of structures to structure of arrays
     soa: dict[str, list[float]] = {}
     for key in keys:
         soa[key] = []

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -247,8 +247,6 @@ def load_data(filename) -> dict[str, SasData]:
             data = data_set
             break
 
-        print(data)
-
         loaded_data[name] = SasData(
             name=name,
             dataset_type=one_dim,
@@ -260,7 +258,18 @@ def load_data(filename) -> dict[str, SasData]:
 
 
 if __name__ == "__main__":
-    data = load_data(test_file)
+    import sys
 
-    for dataset in data.values():
-        print(dataset.summary())
+    if len(sys.argv) > 1:
+        files = sys.argv[1:]
+    else:
+        files = [test_file]
+
+    for f in files:
+        try:
+            data = load_data(f)
+
+            for dataset in data.values():
+                print(dataset.summary())
+        except:
+            print(f)

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -293,5 +293,5 @@ if __name__ == "__main__":
         print(f)
         data = load_data(f)
 
-        # for dataset in data.values():
-        #     print(dataset.summary())
+        for dataset in data.values():
+            print(dataset.summary())

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -108,10 +108,7 @@ def parse_process(node: etree.Element, version: str) -> Process:
 
 
 def parse_beam_size(node: etree.Element, version: str) -> BeamSize:
-    return BeamSize(
-        name=opt_parse(node, "name", version, parse_string),
-        size=opt_parse(node, "size", version, parse_vec3),
-    )
+    return BeamSize(name=attr_parse(node, "name"), size=parse_vec3(node, version))
 
 
 def parse_source(node: etree.Element, version: str) -> Source:

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -1,0 +1,58 @@
+import logging
+from lxml import etree
+
+from sasdata.data import SasData
+from sasdata.dataset_types import one_dim
+from sasdata.metadata import (
+    Instrument,
+    Collimation,
+    Aperture,
+    Source,
+    BeamSize,
+    Detector,
+    Vec3,
+    Rot3,
+    Sample,
+    Process,
+    Metadata,
+)
+
+logger = logging.getLogger(__name__)
+
+test_file = "./example_data/1d_data/ISIS_Polymer_Blend_TK49.xml"
+
+ns = {"cansas": "urn:cansas1d:1.1"}
+
+
+def load_data(filename) -> dict[str, SasData]:
+    loaded_data: dict[str, SasData] = {}
+    tree = etree.parse(filename)
+    root = tree.getroot()
+    if root.tag != "{" + ns["cansas"] + "}SASroot":
+        logger.error(f"Invalid root: {root.tag}")
+        return loaded_data
+    for entry in tree.getroot().findall("cansas:SASentry", ns):
+        name = entry.attrib["name"]
+        metadata = Metadata(
+            title="",
+            run=[],
+            instrument=None,
+            process=[],
+            sample=None,
+            definition=None,
+        )
+        loaded_data[name] = SasData(
+            name=name,
+            dataset_type=one_dim,
+            data_contents={},
+            metadata=metadata,
+            verbose=False,
+        )
+    return loaded_data
+
+
+if __name__ == "__main__":
+    data = load_data(test_file)
+
+    for dataset in data.values():
+        print(dataset.summary())

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -41,8 +41,14 @@ def parse_string(node: etree.Element, _version: str) -> str:
 def parse_quantity(node: etree.Element, version: str) -> Quantity[float]:
     """Pull a single quantity with length units out of an XML node"""
     magnitude = float(parse_string(node, version))
-    unit = node.attrib["unit"]
-    return Quantity(magnitude, unit_parser.parse(unit))
+    try:
+        unit = unit_parser.parse(node.attrib["unit"])
+    except ValueError:
+        logger.warning(
+            f'Could not parse unit "{node.attrib["unit"]}".  Marking value as unitless'
+        )
+        unit = unitless
+    return Quantity(magnitude, unit)
 
 
 def attr_parse(node: etree.Element, key: str) -> str | None:

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -139,7 +139,7 @@ def parse_detector(node: etree.Element) -> Detector:
 def parse_aperture(node: etree.Element) -> Aperture:
     size = opt_parse(node, "size", parse_vec3)
     if size:
-        size_name = attr_parse(node["size"], "name")
+        size_name = attr_parse(node.find("cansas:size", ns), "name")
     else:
         size_name = None
     return Aperture(

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -233,18 +233,20 @@ def parse_data(node: etree.Element, version: str) -> dict[str, Quantity]:
     return result
 
 
+def get_cansas_version(root) -> str | None:
+    """Find the cansas version of a file"""
+    for n, v in ns.items():
+        if root.tag == "{" + v + "}SASroot":
+            return n
+    return None
+
+
 def load_data(filename) -> dict[str, SasData]:
     loaded_data: dict[str, SasData] = {}
     tree = etree.parse(filename)
     root = tree.getroot()
 
-    version: str | None = None
-
-    # Find out cansas version
-    for n, v in ns.items():
-        if root.tag == "{" + v + "}SASroot":
-            version = n
-            break
+    version = get_cansas_version(root)
 
     if version is None:
         logger.error(f"Invalid root: {root.tag}")

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -31,6 +31,14 @@ def _load_text(node: etree.Element, name: str) -> str | None:
     return None
 
 
+def parse_process(node: etree.Element) -> Process:
+    name = _load_text(node, "name")
+    date = _load_text(node, "date")
+    description = _load_text(node, "description")
+    terms = {t.attrib["name"]: t.text for t in node.findall("cansas:term", ns)}
+    return Process(name=name, date=date, description=description, term=terms)
+
+
 def load_data(filename) -> dict[str, SasData]:
     loaded_data: dict[str, SasData] = {}
     tree = etree.parse(filename)
@@ -44,11 +52,16 @@ def load_data(filename) -> dict[str, SasData]:
         run = title = None
         title = _load_text(entry, "Title")
         run = _load_text(entry, "Run")
+
+        processes = [
+            parse_process(node) for node in entry.findall("cansas:SASprocess", ns)
+        ]
+
         metadata = Metadata(
             title=title,
             run=[run] if run is not None else [],
             instrument=None,
-            process=[],
+            process=processes,
             sample=None,
             definition=None,
         )

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -24,6 +24,13 @@ test_file = "./example_data/1d_data/ISIS_Polymer_Blend_TK49.xml"
 ns = {"cansas": "urn:cansas1d:1.1"}
 
 
+# Small helper function to optionally load child text from an element
+def _load_text(node: etree.Element, name: str) -> str | None:
+    if (inner_node := node.find(f"cansas:{name}", ns)) is not None:
+        return inner_node.text
+    return None
+
+
 def load_data(filename) -> dict[str, SasData]:
     loaded_data: dict[str, SasData] = {}
     tree = etree.parse(filename)
@@ -33,9 +40,13 @@ def load_data(filename) -> dict[str, SasData]:
         return loaded_data
     for entry in tree.getroot().findall("cansas:SASentry", ns):
         name = entry.attrib["name"]
+
+        run = title = None
+        title = _load_text(entry, "Title")
+        run = _load_text(entry, "Run")
         metadata = Metadata(
-            title="",
-            run=[],
+            title=title,
+            run=[run] if run is not None else [],
             instrument=None,
             process=[],
             sample=None,

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -40,7 +40,8 @@ def parse_string(node: etree.Element, _version: str) -> str:
 
 def parse_quantity(node: etree.Element, _version: str) -> Quantity[float]:
     """Pull a single quantity with length units out of an XML node"""
-    magnitude = float(node.text)
+    body = "".join(node.itertext())  # Needed to parse all text, even after comments
+    magnitude = float(body)
     unit = node.attrib["unit"]
     return Quantity(magnitude, unit_parser.parse(unit))
 
@@ -189,6 +190,8 @@ def parse_data(node: etree.Element, version: str) -> dict[str, Quantity]:
         struct = {}
         for value in idata.getchildren():
             name = etree.QName(value).localname
+            if value.text is None or value.text.strip() == "":
+                continue
             if name not in us:
                 unit = (
                     unit_parser.parse(value.attrib["unit"])

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -97,6 +97,7 @@ def parse_rot3(node: etree.Element, version: str) -> Rot3:
 
 
 def parse_process(node: etree.Element, version: str) -> Process:
+    """Parse an experimental process"""
     name = opt_parse(node, "name", version, parse_string)
     date = opt_parse(node, "date", version, parse_string)
     description = opt_parse(node, "description", version, parse_string)
@@ -108,10 +109,12 @@ def parse_process(node: etree.Element, version: str) -> Process:
 
 
 def parse_beam_size(node: etree.Element, version: str) -> BeamSize:
+    """Parse a beam size"""
     return BeamSize(name=attr_parse(node, "name"), size=parse_vec3(node, version))
 
 
 def parse_source(node: etree.Element, version: str) -> Source:
+    """Parse a radiation source"""
     radiation = opt_parse(node, "radiation", version, parse_string)
     beam_shape = opt_parse(node, "beam_shape", version, parse_string)
     beam_size = opt_parse(node, "beam_size", version, parse_beam_size)
@@ -131,6 +134,7 @@ def parse_source(node: etree.Element, version: str) -> Source:
 
 
 def parse_detector(node: etree.Element, version: str) -> Detector:
+    """Parse signal detector metadata"""
     return Detector(
         name=opt_parse(node, "name", version, parse_string),
         distance=opt_parse(node, "SDD", version, parse_quantity),
@@ -143,6 +147,7 @@ def parse_detector(node: etree.Element, version: str) -> Detector:
 
 
 def parse_aperture(node: etree.Element, version: str) -> Aperture:
+    """Parse an aperture description"""
     size = opt_parse(node, "size", version, parse_vec3)
     if size:
         size_name = attr_parse(node.find(f"{version}:size", ns), "name")
@@ -158,6 +163,7 @@ def parse_aperture(node: etree.Element, version: str) -> Aperture:
 
 
 def parse_collimation(node: etree.Element, version: str) -> Collimation:
+    """Parse a beam collimation"""
     return Collimation(
         length=opt_parse(node, "length", version, parse_quantity),
         apertures=all_parse(node, "aperture", version, parse_aperture),
@@ -165,6 +171,7 @@ def parse_collimation(node: etree.Element, version: str) -> Collimation:
 
 
 def parse_instrument(node: etree.Element, version: str) -> Instrument:
+    """Parse instrument metadata"""
     source = opt_parse(node, "SASsource", version, parse_source)
     detector = all_parse(node, "SASdetector", version, parse_detector)
     collimations = all_parse(node, "SAScollimation", version, parse_collimation)
@@ -172,6 +179,7 @@ def parse_instrument(node: etree.Element, version: str) -> Instrument:
 
 
 def parse_sample(node: etree.Element, version: str) -> Sample:
+    """Parse sample metadata"""
     return Sample(
         name=attr_parse(node, "name"),
         sample_id=opt_parse(node, "ID", version, parse_string),
@@ -187,6 +195,7 @@ def parse_sample(node: etree.Element, version: str) -> Sample:
 
 
 def parse_data(node: etree.Element, version: str) -> dict[str, Quantity]:
+    """Parse scattering data"""
     aos = []
     keys = set()
     # Units for quantities
@@ -242,6 +251,7 @@ def get_cansas_version(root) -> str | None:
 
 
 def load_data(filename) -> dict[str, SasData]:
+    """Load scattering data from an XML file"""
     loaded_data: dict[str, SasData] = {}
     tree = etree.parse(filename)
     root = tree.getroot()

--- a/test/sasdataloader/reference/ISIS_1_0.txt
+++ b/test/sasdataloader/reference/ISIS_1_0.txt
@@ -11,7 +11,9 @@ Process:
     Name: Mantid generated CanSAS1D XML
     Date: 02-Aug-2013 16:54:14
     Description: None
-    Term: {'svn': '2.5.3', 'user_file': 'K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt'}
+    Terms:
+        svn: 2.5.3
+        user_file: K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt
 Sample:
    ID:           TK49 c10_SANS
    Transmission: None

--- a/test/sasdataloader/reference/ISIS_1_0.txt
+++ b/test/sasdataloader/reference/ISIS_1_0.txt
@@ -1,0 +1,47 @@
+79680main_1D_2.2_10.0
+  Q
+  I
+Metadata:
+
+  TK49 c10_SANS, Run: 79680
+  =========================
+
+Definition: TK49 c10_SANS
+Process:
+    Name: Mantid generated CanSAS1D XML
+    Date: 02-Aug-2013 16:54:14
+    Description: None
+    Term: {'svn': '2.5.3', 'user_file': 'K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt'}
+Sample:
+   ID:           TK49 c10_SANS
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         HAB
+   Distance:     0.575 m
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Detector:
+   Name:         main-detector-bank
+   Distance:     4.14502 m
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None

--- a/test/sasdataloader/reference/ISIS_1_1.txt
+++ b/test/sasdataloader/reference/ISIS_1_1.txt
@@ -11,7 +11,9 @@ Process:
     Name: Mantid generated CanSAS1D XML
     Date: 02-Aug-2013 16:53:56
     Description: None
-    Term: {'svn': '2.5.3', 'user_file': 'K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt'}
+    Terms:
+        svn: 2.5.3
+        user_file: K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt
 Sample:
    ID:           TK49 c10_SANS
    Transmission: None

--- a/test/sasdataloader/reference/ISIS_1_1.txt
+++ b/test/sasdataloader/reference/ISIS_1_1.txt
@@ -1,0 +1,47 @@
+79680main_1D_2.2_10.0
+  Q
+  I
+Metadata:
+
+  TK49 c10_SANS, Run: 79680
+  =========================
+
+Definition: TK49 c10_SANS
+Process:
+    Name: Mantid generated CanSAS1D XML
+    Date: 02-Aug-2013 16:53:56
+    Description: None
+    Term: {'svn': '2.5.3', 'user_file': 'K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt'}
+Sample:
+   ID:           TK49 c10_SANS
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         HAB
+   Distance:     0.575 m
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Detector:
+   Name:         main-detector-bank
+   Distance:     4.14502 m
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None

--- a/test/sasdataloader/reference/ISIS_1_1_doubletrans.txt
+++ b/test/sasdataloader/reference/ISIS_1_1_doubletrans.txt
@@ -11,7 +11,9 @@ Process:
     Name: Mantid generated CanSAS1D XML
     Date: 02-Aug-2013 16:53:56
     Description: None
-    Term: {'svn': '2.5.3', 'user_file': 'K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt'}
+    Terms:
+        svn: 2.5.3
+        user_file: K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt
 Sample:
    ID:           TK49 c10_SANS
    Transmission: None

--- a/test/sasdataloader/reference/ISIS_1_1_doubletrans.txt
+++ b/test/sasdataloader/reference/ISIS_1_1_doubletrans.txt
@@ -1,0 +1,47 @@
+79680main_1D_2.2_10.0
+  Q
+  I
+Metadata:
+
+  TK49 c10_SANS, Run: 79680
+  =========================
+
+Definition: TK49 c10_SANS
+Process:
+    Name: Mantid generated CanSAS1D XML
+    Date: 02-Aug-2013 16:53:56
+    Description: None
+    Term: {'svn': '2.5.3', 'user_file': 'K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt'}
+Sample:
+   ID:           TK49 c10_SANS
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         HAB
+   Distance:     0.575 m
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Detector:
+   Name:         main-detector-bank
+   Distance:     4.14502 m
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None

--- a/test/sasdataloader/reference/ISIS_1_1_notrans.txt
+++ b/test/sasdataloader/reference/ISIS_1_1_notrans.txt
@@ -11,7 +11,9 @@ Process:
     Name: Mantid generated CanSAS1D XML
     Date: 02-Aug-2013 16:53:56
     Description: None
-    Term: {'svn': '2.5.3', 'user_file': 'K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt'}
+    Terms:
+        svn: 2.5.3
+        user_file: K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt
 Sample:
    ID:           TK49 c10_SANS
    Transmission: None

--- a/test/sasdataloader/reference/ISIS_1_1_notrans.txt
+++ b/test/sasdataloader/reference/ISIS_1_1_notrans.txt
@@ -1,0 +1,47 @@
+79680main_1D_2.2_10.0
+  Q
+  I
+Metadata:
+
+  TK49 c10_SANS, Run: 79680
+  =========================
+
+Definition: TK49 c10_SANS
+Process:
+    Name: Mantid generated CanSAS1D XML
+    Date: 02-Aug-2013 16:53:56
+    Description: None
+    Term: {'svn': '2.5.3', 'user_file': 'K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt'}
+Sample:
+   ID:           TK49 c10_SANS
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         HAB
+   Distance:     0.575 m
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Detector:
+   Name:         main-detector-bank
+   Distance:     4.14502 m
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None

--- a/test/sasdataloader/reference/TestExtensions.txt
+++ b/test/sasdataloader/reference/TestExtensions.txt
@@ -1,4 +1,4 @@
-SasData01
+TK49 c10_SANS
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/TestExtensions.txt
+++ b/test/sasdataloader/reference/TestExtensions.txt
@@ -11,7 +11,9 @@ Process:
     Name: Mantid generated CanSAS1D XML
     Date: 02-Aug-2013 16:53:56
     Description: 
-    Term: {'svn': '2.5.3', 'user_file': 'K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt'}
+    Terms:
+        svn: 2.5.3
+        user_file: K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt
 Sample:
    ID:           TK49 c10_SANS
    Transmission: None

--- a/test/sasdataloader/reference/TestExtensions.txt
+++ b/test/sasdataloader/reference/TestExtensions.txt
@@ -1,4 +1,4 @@
-None
+SasData01
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/TestExtensions.txt
+++ b/test/sasdataloader/reference/TestExtensions.txt
@@ -10,7 +10,7 @@ Definition: TK49 c10_SANS
 Process:
     Name: Mantid generated CanSAS1D XML
     Date: 02-Aug-2013 16:53:56
-    Description: None
+    Description: 
     Term: {'svn': '2.5.3', 'user_file': 'K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt'}
 Sample:
    ID:           TK49 c10_SANS

--- a/test/sasdataloader/reference/TestExtensions.txt
+++ b/test/sasdataloader/reference/TestExtensions.txt
@@ -1,0 +1,47 @@
+None
+  Q
+  I
+Metadata:
+
+  TK49 c10_SANS, Run: 79680
+  =========================
+
+Definition: TK49 c10_SANS
+Process:
+    Name: Mantid generated CanSAS1D XML
+    Date: 02-Aug-2013 16:53:56
+    Description: None
+    Term: {'svn': '2.5.3', 'user_file': 'K:/masks/MASKLOQ_MAN_132E_Lu_Banjo_12mm.txt'}
+Sample:
+   ID:           TK49 c10_SANS
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         HAB
+   Distance:     575.0 mm
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Detector:
+   Name:         main-detector-bank
+   Distance:     4145.02 mm
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None

--- a/test/sasdataloader/reference/cansas1d.txt
+++ b/test/sasdataloader/reference/cansas1d.txt
@@ -1,4 +1,4 @@
-SasData01
+Test title
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/cansas1d.txt
+++ b/test/sasdataloader/reference/cansas1d.txt
@@ -16,6 +16,12 @@ Process:
         sector_width: 180.0 deg
         sector_orient: 0.0 deg
         MASK_file: USER:MASK.COM
+    Notes:
+        AvA1 0.0000E+00 AsA2 1.0000E+00 XvA3 1.0526E+03 XsA4
+				5.2200E-02 XfA5 0.0000E+00
+        S... 13597 0 2.26E+02 2A 5mM 0%D2O Sbak 13594 0 1.13E+02
+				H2O Buffer
+        V... 13552 3 1.00E+00 H2O5m
 Process:
     Name: NCNR-IGOR
     Date: 03-SEP-2006 11:42:47
@@ -31,6 +37,8 @@ Process:
         ABS:DSTAND: 1.0 mm
         ABS:IZERO: 230.09
         ABS:XSECT: 1.0 mm
+    Notes:
+        No Information
 Sample:
    ID:           SI600-new-long
    Transmission: 0.327

--- a/test/sasdataloader/reference/cansas1d.txt
+++ b/test/sasdataloader/reference/cansas1d.txt
@@ -1,4 +1,4 @@
-None
+SasData01
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/cansas1d.txt
+++ b/test/sasdataloader/reference/cansas1d.txt
@@ -11,12 +11,26 @@ Process:
     Name: spol
     Date: 04-Sep-2007 18:35:02
     Description: None
-    Term: {'radialstep': '10.000', 'sector_width': '180.0', 'sector_orient': '0.0', 'MASK_file': 'USER:MASK.COM'}
+    Terms:
+        radialstep: 10.0 mm
+        sector_width: 180.0 deg
+        sector_orient: 0.0 deg
+        MASK_file: USER:MASK.COM
 Process:
     Name: NCNR-IGOR
     Date: 03-SEP-2006 11:42:47
     Description: 
-    Term: {'average_type': 'Circular', 'SAM_file': 'SEP06064.SA3_AJJ_L205', 'BKD_file': 'SEP06064.SA3_AJJ_L205', 'EMP_file': 'SEP06064.SA3_AJJ_L205', 'DIV_file': 'SEP06064.SA3_AJJ_L205', 'MASK_file': 'SEP06064.SA3_AJJ_L205', 'ABS:TSTAND': '1', 'ABS:DSTAND': '1', 'ABS:IZERO': '230.09', 'ABS:XSECT': '1'}
+    Terms:
+        average_type: Circular
+        SAM_file: SEP06064.SA3_AJJ_L205
+        BKD_file: SEP06064.SA3_AJJ_L205
+        EMP_file: SEP06064.SA3_AJJ_L205
+        DIV_file: SEP06064.SA3_AJJ_L205
+        MASK_file: SEP06064.SA3_AJJ_L205
+        ABS:TSTAND: 1
+        ABS:DSTAND: 1.0 mm
+        ABS:IZERO: 230.09
+        ABS:XSECT: 1.0 mm
 Sample:
    ID:           SI600-new-long
    Transmission: 0.327

--- a/test/sasdataloader/reference/cansas1d.txt
+++ b/test/sasdataloader/reference/cansas1d.txt
@@ -1,0 +1,44 @@
+None
+  Q
+  I
+Metadata:
+
+  Test title, Run: 1234
+  =====================
+
+Definition: Test title
+Process:
+    Name: spol
+    Date: 04-Sep-2007 18:35:02
+    Description: None
+    Term: {'radialstep': '10.000', 'sector_width': '180.0', 'sector_orient': '0.0', 'MASK_file': 'USER:MASK.COM'}
+Process:
+    Name: NCNR-IGOR
+    Date: 03-SEP-2006 11:42:47
+    Description: None
+    Term: {'average_type': 'Circular', 'SAM_file': 'SEP06064.SA3_AJJ_L205', 'BKD_file': 'SEP06064.SA3_AJJ_L205', 'EMP_file': 'SEP06064.SA3_AJJ_L205', 'DIV_file': 'SEP06064.SA3_AJJ_L205', 'MASK_file': 'SEP06064.SA3_AJJ_L205', 'ABS:TSTAND': '1', 'ABS:DSTAND': '1', 'ABS:IZERO': '230.09', 'ABS:XSECT': '1'}
+Sample:
+   ID:           SI600-new-long
+   Transmission: 0.327
+   Thickness:    1.03 mm
+   Temperature:  0.0 K
+   Position:     Vec3(x=10.0 mm, y=0.0 mm, z=None)
+   Orientation:  Rot3(roll=22.5 deg, pitch=0.02 deg, yaw=None)
+Collimation:
+   Length: 123.0 mm
+Detector:
+   Name:         fictional hybrid
+   Distance:     4.15 m
+   Offset:       Vec3(x=1.0 mm, y=2.0 mm, z=None)
+   Orientation:  Rot3(roll=1.0 deg, pitch=0.0 deg, yaw=0.0 deg)
+   Beam center:  Vec3(x=322.64 mm, y=327.68 mm, z=None)
+   Pixel size:   Vec3(x=5.0 mm, y=5.0 mm, z=None)
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             disc
+    Wavelength:        6.0 Å
+    Min. Wavelength:   0.22 nm
+    Max. Wavelength:   1.0 nm
+    Wavelength Spread: 14.3 %
+    Beam Size:         BeamSize(name=None, size=None)

--- a/test/sasdataloader/reference/cansas1d.txt
+++ b/test/sasdataloader/reference/cansas1d.txt
@@ -15,7 +15,7 @@ Process:
 Process:
     Name: NCNR-IGOR
     Date: 03-SEP-2006 11:42:47
-    Description: None
+    Description: 
     Term: {'average_type': 'Circular', 'SAM_file': 'SEP06064.SA3_AJJ_L205', 'BKD_file': 'SEP06064.SA3_AJJ_L205', 'EMP_file': 'SEP06064.SA3_AJJ_L205', 'DIV_file': 'SEP06064.SA3_AJJ_L205', 'MASK_file': 'SEP06064.SA3_AJJ_L205', 'ABS:TSTAND': '1', 'ABS:DSTAND': '1', 'ABS:IZERO': '230.09', 'ABS:XSECT': '1'}
 Sample:
    ID:           SI600-new-long

--- a/test/sasdataloader/reference/cansas1d.txt
+++ b/test/sasdataloader/reference/cansas1d.txt
@@ -41,4 +41,4 @@ Source:
     Min. Wavelength:   0.22 nm
     Max. Wavelength:   1.0 nm
     Wavelength Spread: 14.3 %
-    Beam Size:         BeamSize(name=None, size=None)
+    Beam Size:         BeamSize(name='bm', size=Vec3(x=12.0 mm, y=13.0 mm, z=None))

--- a/test/sasdataloader/reference/cansas1d_badunits.txt
+++ b/test/sasdataloader/reference/cansas1d_badunits.txt
@@ -11,12 +11,26 @@ Process:
     Name: spol
     Date: 04-Sep-2007 18:35:02
     Description: None
-    Term: {'radialstep': '10.000', 'sector_width': '4.1416', 'sector_orient': '0.0', 'MASK_file': 'USER:MASK.COM'}
+    Terms:
+        radialstep: 10.0 mm
+        sector_width: 4.1416 rad
+        sector_orient: 0.0 deg
+        MASK_file: USER:MASK.COM
 Process:
     Name: NCNR-IGOR
     Date: 03-SEP-2006 11:42:47
     Description: 
-    Term: {'average_type': 'Circular', 'SAM_file': 'SEP06064.SA3_AJJ_L205', 'BKD_file': 'SEP06064.SA3_AJJ_L205', 'EMP_file': 'SEP06064.SA3_AJJ_L205', 'DIV_file': 'SEP06064.SA3_AJJ_L205', 'MASK_file': 'SEP06064.SA3_AJJ_L205', 'ABS:TSTAND': '1', 'ABS:DSTAND': '1', 'ABS:IZERO': '230.09', 'ABS:XSECT': '1'}
+    Terms:
+        average_type: Circular
+        SAM_file: SEP06064.SA3_AJJ_L205
+        BKD_file: SEP06064.SA3_AJJ_L205
+        EMP_file: SEP06064.SA3_AJJ_L205
+        DIV_file: SEP06064.SA3_AJJ_L205
+        MASK_file: SEP06064.SA3_AJJ_L205
+        ABS:TSTAND: 1
+        ABS:DSTAND: 1.0 mm
+        ABS:IZERO: 230.09
+        ABS:XSECT: 1.0 mm
 Sample:
    ID:           SI600-new-long
    Transmission: 0.327

--- a/test/sasdataloader/reference/cansas1d_badunits.txt
+++ b/test/sasdataloader/reference/cansas1d_badunits.txt
@@ -1,4 +1,4 @@
-SasData01
+Test title
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/cansas1d_badunits.txt
+++ b/test/sasdataloader/reference/cansas1d_badunits.txt
@@ -16,6 +16,12 @@ Process:
         sector_width: 4.1416 rad
         sector_orient: 0.0 deg
         MASK_file: USER:MASK.COM
+    Notes:
+        AvA1 0.0000E+00 AsA2 1.0000E+00 XvA3 1.0526E+03 XsA4
+				5.2200E-02 XfA5 0.0000E+00
+        S... 13597 0 2.26E+02 2A 5mM 0%D2O Sbak 13594 0 1.13E+02
+				H2O Buffer
+        V... 13552 3 1.00E+00 H2O5m
 Process:
     Name: NCNR-IGOR
     Date: 03-SEP-2006 11:42:47

--- a/test/sasdataloader/reference/cansas1d_badunits.txt
+++ b/test/sasdataloader/reference/cansas1d_badunits.txt
@@ -1,4 +1,4 @@
-None
+SasData01
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/cansas1d_badunits.txt
+++ b/test/sasdataloader/reference/cansas1d_badunits.txt
@@ -1,0 +1,44 @@
+None
+  Q
+  I
+Metadata:
+
+  Test title, Run: 1234
+  =====================
+
+Definition: Test title
+Process:
+    Name: spol
+    Date: 04-Sep-2007 18:35:02
+    Description: None
+    Term: {'radialstep': '10.000', 'sector_width': '4.1416', 'sector_orient': '0.0', 'MASK_file': 'USER:MASK.COM'}
+Process:
+    Name: NCNR-IGOR
+    Date: 03-SEP-2006 11:42:47
+    Description: 
+    Term: {'average_type': 'Circular', 'SAM_file': 'SEP06064.SA3_AJJ_L205', 'BKD_file': 'SEP06064.SA3_AJJ_L205', 'EMP_file': 'SEP06064.SA3_AJJ_L205', 'DIV_file': 'SEP06064.SA3_AJJ_L205', 'MASK_file': 'SEP06064.SA3_AJJ_L205', 'ABS:TSTAND': '1', 'ABS:DSTAND': '1', 'ABS:IZERO': '230.09', 'ABS:XSECT': '1'}
+Sample:
+   ID:           SI600-new-long
+   Transmission: 0.327
+   Thickness:    0.00103 none
+   Temperature:  0.0 K
+   Position:     Vec3(x=10000000.0 nm, y=0.0 mm, z=None)
+   Orientation:  Rot3(roll=0.39269908 rad, pitch=0.00034906585 rad, yaw=None)
+Collimation:
+   Length: 0.123 m
+Detector:
+   Name:         fictional hybrid
+   Distance:     4.15 m
+   Offset:       Vec3(x=1000000.0 nm, y=2000.0 none, z=None)
+   Orientation:  Rot3(roll=0.0174533 none, pitch=0.0 rad, yaw=0.0 none)
+   Beam center:  Vec3(x=0.32264 m, y=0.32768 m, z=None)
+   Pixel size:   Vec3(x=0.5 cm, y=0.5 cm, z=None)
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             disc
+    Wavelength:        0.6 nm
+    Min. Wavelength:   2.2 Å
+    Max. Wavelength:   10.0 Å
+    Wavelength Spread: 14.3 %
+    Beam Size:         BeamSize(name=None, size=None)

--- a/test/sasdataloader/reference/cansas1d_badunits.txt
+++ b/test/sasdataloader/reference/cansas1d_badunits.txt
@@ -29,8 +29,8 @@ Collimation:
 Detector:
    Name:         fictional hybrid
    Distance:     4.15 m
-   Offset:       Vec3(x=1000000.0 nm, y=2000.0 none, z=None)
-   Orientation:  Rot3(roll=0.0174533 none, pitch=0.0 rad, yaw=0.0 none)
+   Offset:       Vec3(x=1000000.0 nm, y=2000.0 µm, z=None)
+   Orientation:  Rot3(roll=0.0174533 rad, pitch=0.0 rad, yaw=0.0 rad)
    Beam center:  Vec3(x=0.32264 m, y=0.32768 m, z=None)
    Pixel size:   Vec3(x=0.5 cm, y=0.5 cm, z=None)
    Slit length:  None
@@ -41,4 +41,4 @@ Source:
     Min. Wavelength:   2.2 Å
     Max. Wavelength:   10.0 Å
     Wavelength Spread: 14.3 %
-    Beam Size:         BeamSize(name='bm', size=Vec3(x=0.012 m, y=13000.0 none, z=None))
+    Beam Size:         BeamSize(name='bm', size=Vec3(x=0.012 m, y=13000.0 µm, z=None))

--- a/test/sasdataloader/reference/cansas1d_badunits.txt
+++ b/test/sasdataloader/reference/cansas1d_badunits.txt
@@ -41,4 +41,4 @@ Source:
     Min. Wavelength:   2.2 Å
     Max. Wavelength:   10.0 Å
     Wavelength Spread: 14.3 %
-    Beam Size:         BeamSize(name=None, size=None)
+    Beam Size:         BeamSize(name='bm', size=Vec3(x=0.012 m, y=13000.0 none, z=None))

--- a/test/sasdataloader/reference/cansas1d_notitle.txt
+++ b/test/sasdataloader/reference/cansas1d_notitle.txt
@@ -16,6 +16,12 @@ Process:
         sector_width: 180.0 deg
         sector_orient: 0.0 deg
         MASK_file: USER:MASK.COM
+    Notes:
+        AvA1 0.0000E+00 AsA2 1.0000E+00 XvA3 1.0526E+03 XsA4
+				5.2200E-02 XfA5 0.0000E+00
+        S... 13597 0 2.26E+02 2A 5mM 0%D2O Sbak 13594 0 1.13E+02
+				H2O Buffer
+        V... 13552 3 1.00E+00 H2O5m
 Process:
     Name: NCNR-IGOR
     Date: 03-SEP-2006 11:42:47
@@ -31,6 +37,8 @@ Process:
         ABS:DSTAND: 1.0 mm
         ABS:IZERO: 230.09
         ABS:XSECT: 1.0 mm
+    Notes:
+        No Information
 Sample:
    ID:           SI600-new-long
    Transmission: 0.327

--- a/test/sasdataloader/reference/cansas1d_notitle.txt
+++ b/test/sasdataloader/reference/cansas1d_notitle.txt
@@ -1,4 +1,4 @@
-None
+SasData01
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/cansas1d_notitle.txt
+++ b/test/sasdataloader/reference/cansas1d_notitle.txt
@@ -11,12 +11,26 @@ Process:
     Name: spol
     Date: 04-Sep-2007 18:35:02
     Description: None
-    Term: {'radialstep': '10.000', 'sector_width': '180.0', 'sector_orient': '0.0', 'MASK_file': 'USER:MASK.COM'}
+    Terms:
+        radialstep: 10.0 mm
+        sector_width: 180.0 deg
+        sector_orient: 0.0 deg
+        MASK_file: USER:MASK.COM
 Process:
     Name: NCNR-IGOR
     Date: 03-SEP-2006 11:42:47
     Description: 
-    Term: {'average_type': 'Circular', 'SAM_file': 'SEP06064.SA3_AJJ_L205', 'BKD_file': 'SEP06064.SA3_AJJ_L205', 'EMP_file': 'SEP06064.SA3_AJJ_L205', 'DIV_file': 'SEP06064.SA3_AJJ_L205', 'MASK_file': 'SEP06064.SA3_AJJ_L205', 'ABS:TSTAND': '1', 'ABS:DSTAND': '1', 'ABS:IZERO': '230.09', 'ABS:XSECT': '1'}
+    Terms:
+        average_type: Circular
+        SAM_file: SEP06064.SA3_AJJ_L205
+        BKD_file: SEP06064.SA3_AJJ_L205
+        EMP_file: SEP06064.SA3_AJJ_L205
+        DIV_file: SEP06064.SA3_AJJ_L205
+        MASK_file: SEP06064.SA3_AJJ_L205
+        ABS:TSTAND: 1
+        ABS:DSTAND: 1.0 mm
+        ABS:IZERO: 230.09
+        ABS:XSECT: 1.0 mm
 Sample:
    ID:           SI600-new-long
    Transmission: 0.327

--- a/test/sasdataloader/reference/cansas1d_notitle.txt
+++ b/test/sasdataloader/reference/cansas1d_notitle.txt
@@ -1,0 +1,44 @@
+None
+  Q
+  I
+Metadata:
+
+  None, Run: 1234
+  ===========
+
+Definition: None
+Process:
+    Name: spol
+    Date: 04-Sep-2007 18:35:02
+    Description: None
+    Term: {'radialstep': '10.000', 'sector_width': '180.0', 'sector_orient': '0.0', 'MASK_file': 'USER:MASK.COM'}
+Process:
+    Name: NCNR-IGOR
+    Date: 03-SEP-2006 11:42:47
+    Description: 
+    Term: {'average_type': 'Circular', 'SAM_file': 'SEP06064.SA3_AJJ_L205', 'BKD_file': 'SEP06064.SA3_AJJ_L205', 'EMP_file': 'SEP06064.SA3_AJJ_L205', 'DIV_file': 'SEP06064.SA3_AJJ_L205', 'MASK_file': 'SEP06064.SA3_AJJ_L205', 'ABS:TSTAND': '1', 'ABS:DSTAND': '1', 'ABS:IZERO': '230.09', 'ABS:XSECT': '1'}
+Sample:
+   ID:           SI600-new-long
+   Transmission: 0.327
+   Thickness:    1.03 mm
+   Temperature:  0.0 K
+   Position:     Vec3(x=10.0 mm, y=0.0 mm, z=None)
+   Orientation:  Rot3(roll=22.5 deg, pitch=0.02 deg, yaw=None)
+Collimation:
+   Length: 123.0 mm
+Detector:
+   Name:         fictional hybrid
+   Distance:     4.15 m
+   Offset:       Vec3(x=1.0 mm, y=2.0 mm, z=None)
+   Orientation:  Rot3(roll=1.0 deg, pitch=0.0 deg, yaw=0.0 deg)
+   Beam center:  Vec3(x=322.64 mm, y=327.68 mm, z=None)
+   Pixel size:   Vec3(x=5.0 mm, y=5.0 mm, z=None)
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             disc
+    Wavelength:        6.0 Å
+    Min. Wavelength:   0.22 nm
+    Max. Wavelength:   1.0 nm
+    Wavelength Spread: 14.3 %
+    Beam Size:         BeamSize(name=None, size=None)

--- a/test/sasdataloader/reference/cansas1d_notitle.txt
+++ b/test/sasdataloader/reference/cansas1d_notitle.txt
@@ -41,4 +41,4 @@ Source:
     Min. Wavelength:   0.22 nm
     Max. Wavelength:   1.0 nm
     Wavelength Spread: 14.3 %
-    Beam Size:         BeamSize(name=None, size=None)
+    Beam Size:         BeamSize(name='bm', size=Vec3(x=12.0 mm, y=13.0 mm, z=None))

--- a/test/sasdataloader/reference/cansas1d_slit.txt
+++ b/test/sasdataloader/reference/cansas1d_slit.txt
@@ -13,12 +13,26 @@ Process:
     Name: spol
     Date: 04-Sep-2007 18:35:02
     Description: None
-    Term: {'radialstep': '10.000', 'sector_width': '180.0', 'sector_orient': '0.0', 'MASK_file': 'USER:MASK.COM'}
+    Terms:
+        radialstep: 10.0 mm
+        sector_width: 180.0 deg
+        sector_orient: 0.0 deg
+        MASK_file: USER:MASK.COM
 Process:
     Name: NCNR-IGOR
     Date: 03-SEP-2006 11:42:47
     Description: 
-    Term: {'average_type': 'Circular', 'SAM_file': 'SEP06064.SA3_AJJ_L205', 'BKD_file': 'SEP06064.SA3_AJJ_L205', 'EMP_file': 'SEP06064.SA3_AJJ_L205', 'DIV_file': 'SEP06064.SA3_AJJ_L205', 'MASK_file': 'SEP06064.SA3_AJJ_L205', 'ABS:TSTAND': '1', 'ABS:DSTAND': '1', 'ABS:IZERO': '230.09', 'ABS:XSECT': '1'}
+    Terms:
+        average_type: Circular
+        SAM_file: SEP06064.SA3_AJJ_L205
+        BKD_file: SEP06064.SA3_AJJ_L205
+        EMP_file: SEP06064.SA3_AJJ_L205
+        DIV_file: SEP06064.SA3_AJJ_L205
+        MASK_file: SEP06064.SA3_AJJ_L205
+        ABS:TSTAND: 1
+        ABS:DSTAND: 1.0 mm
+        ABS:IZERO: 230.09
+        ABS:XSECT: 1.0 mm
 Sample:
    ID:           SI600-new-long
    Transmission: 0.327

--- a/test/sasdataloader/reference/cansas1d_slit.txt
+++ b/test/sasdataloader/reference/cansas1d_slit.txt
@@ -18,6 +18,12 @@ Process:
         sector_width: 180.0 deg
         sector_orient: 0.0 deg
         MASK_file: USER:MASK.COM
+    Notes:
+        AvA1 0.0000E+00 AsA2 1.0000E+00 XvA3 1.0526E+03 XsA4
+				5.2200E-02 XfA5 0.0000E+00
+        S... 13597 0 2.26E+02 2A 5mM 0%D2O Sbak 13594 0 1.13E+02
+				H2O Buffer
+        V... 13552 3 1.00E+00 H2O5m
 Process:
     Name: NCNR-IGOR
     Date: 03-SEP-2006 11:42:47

--- a/test/sasdataloader/reference/cansas1d_slit.txt
+++ b/test/sasdataloader/reference/cansas1d_slit.txt
@@ -1,4 +1,4 @@
-SasData01
+Test title
   dQw
   dQl
   Q

--- a/test/sasdataloader/reference/cansas1d_slit.txt
+++ b/test/sasdataloader/reference/cansas1d_slit.txt
@@ -1,4 +1,4 @@
-None
+SasData01
   dQw
   dQl
   Q

--- a/test/sasdataloader/reference/cansas1d_slit.txt
+++ b/test/sasdataloader/reference/cansas1d_slit.txt
@@ -1,8 +1,8 @@
 None
-  I
+  dQw
   dQl
   Q
-  dQw
+  I
 Metadata:
 
   Test title, Run: 1234

--- a/test/sasdataloader/reference/cansas1d_slit.txt
+++ b/test/sasdataloader/reference/cansas1d_slit.txt
@@ -43,4 +43,4 @@ Source:
     Min. Wavelength:   0.22 nm
     Max. Wavelength:   1.0 nm
     Wavelength Spread: 14.3 %
-    Beam Size:         BeamSize(name=None, size=None)
+    Beam Size:         BeamSize(name='bm', size=Vec3(x=12.0 mm, y=13.0 mm, z=None))

--- a/test/sasdataloader/reference/cansas1d_slit.txt
+++ b/test/sasdataloader/reference/cansas1d_slit.txt
@@ -1,0 +1,46 @@
+None
+  I
+  dQl
+  Q
+  dQw
+Metadata:
+
+  Test title, Run: 1234
+  =====================
+
+Definition: Test title
+Process:
+    Name: spol
+    Date: 04-Sep-2007 18:35:02
+    Description: None
+    Term: {'radialstep': '10.000', 'sector_width': '180.0', 'sector_orient': '0.0', 'MASK_file': 'USER:MASK.COM'}
+Process:
+    Name: NCNR-IGOR
+    Date: 03-SEP-2006 11:42:47
+    Description: 
+    Term: {'average_type': 'Circular', 'SAM_file': 'SEP06064.SA3_AJJ_L205', 'BKD_file': 'SEP06064.SA3_AJJ_L205', 'EMP_file': 'SEP06064.SA3_AJJ_L205', 'DIV_file': 'SEP06064.SA3_AJJ_L205', 'MASK_file': 'SEP06064.SA3_AJJ_L205', 'ABS:TSTAND': '1', 'ABS:DSTAND': '1', 'ABS:IZERO': '230.09', 'ABS:XSECT': '1'}
+Sample:
+   ID:           SI600-new-long
+   Transmission: 0.327
+   Thickness:    1.03 mm
+   Temperature:  0.0 K
+   Position:     Vec3(x=10.0 mm, y=0.0 mm, z=None)
+   Orientation:  Rot3(roll=22.5 deg, pitch=0.02 deg, yaw=None)
+Collimation:
+   Length: 123.0 mm
+Detector:
+   Name:         fictional hybrid
+   Distance:     4.15 m
+   Offset:       Vec3(x=1.0 mm, y=2.0 mm, z=None)
+   Orientation:  Rot3(roll=1.0 deg, pitch=0.0 deg, yaw=0.0 deg)
+   Beam center:  Vec3(x=322.64 mm, y=327.68 mm, z=None)
+   Pixel size:   Vec3(x=5.0 mm, y=5.0 mm, z=None)
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             disc
+    Wavelength:        6.0 Å
+    Min. Wavelength:   0.22 nm
+    Max. Wavelength:   1.0 nm
+    Wavelength Spread: 14.3 %
+    Beam Size:         BeamSize(name=None, size=None)

--- a/test/sasdataloader/reference/cansas1d_units.txt
+++ b/test/sasdataloader/reference/cansas1d_units.txt
@@ -11,12 +11,26 @@ Process:
     Name: spol
     Date: 04-Sep-2007 18:35:02
     Description: None
-    Term: {'radialstep': '10.000', 'sector_width': '4.1416', 'sector_orient': '0.0', 'MASK_file': 'USER:MASK.COM'}
+    Terms:
+        radialstep: 10.0 mm
+        sector_width: 4.1416 rad
+        sector_orient: 0.0 deg
+        MASK_file: USER:MASK.COM
 Process:
     Name: NCNR-IGOR
     Date: 03-SEP-2006 11:42:47
     Description: 
-    Term: {'average_type': 'Circular', 'SAM_file': 'SEP06064.SA3_AJJ_L205', 'BKD_file': 'SEP06064.SA3_AJJ_L205', 'EMP_file': 'SEP06064.SA3_AJJ_L205', 'DIV_file': 'SEP06064.SA3_AJJ_L205', 'MASK_file': 'SEP06064.SA3_AJJ_L205', 'ABS:TSTAND': '1', 'ABS:DSTAND': '1', 'ABS:IZERO': '230.09', 'ABS:XSECT': '1'}
+    Terms:
+        average_type: Circular
+        SAM_file: SEP06064.SA3_AJJ_L205
+        BKD_file: SEP06064.SA3_AJJ_L205
+        EMP_file: SEP06064.SA3_AJJ_L205
+        DIV_file: SEP06064.SA3_AJJ_L205
+        MASK_file: SEP06064.SA3_AJJ_L205
+        ABS:TSTAND: 1
+        ABS:DSTAND: 1.0 mm
+        ABS:IZERO: 230.09
+        ABS:XSECT: 1.0 mm
 Sample:
    ID:           SI600-new-long
    Transmission: 0.327

--- a/test/sasdataloader/reference/cansas1d_units.txt
+++ b/test/sasdataloader/reference/cansas1d_units.txt
@@ -1,4 +1,4 @@
-SasData01
+Test title
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/cansas1d_units.txt
+++ b/test/sasdataloader/reference/cansas1d_units.txt
@@ -16,6 +16,12 @@ Process:
         sector_width: 4.1416 rad
         sector_orient: 0.0 deg
         MASK_file: USER:MASK.COM
+    Notes:
+        AvA1 0.0000E+00 AsA2 1.0000E+00 XvA3 1.0526E+03 XsA4
+				5.2200E-02 XfA5 0.0000E+00
+        S... 13597 0 2.26E+02 2A 5mM 0%D2O Sbak 13594 0 1.13E+02
+				H2O Buffer
+        V... 13552 3 1.00E+00 H2O5m
 Process:
     Name: NCNR-IGOR
     Date: 03-SEP-2006 11:42:47

--- a/test/sasdataloader/reference/cansas1d_units.txt
+++ b/test/sasdataloader/reference/cansas1d_units.txt
@@ -1,4 +1,4 @@
-None
+SasData01
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/cansas1d_units.txt
+++ b/test/sasdataloader/reference/cansas1d_units.txt
@@ -29,8 +29,8 @@ Collimation:
 Detector:
    Name:         fictional hybrid
    Distance:     4.15 m
-   Offset:       Vec3(x=1000000.0 nm, y=2000.0 none, z=None)
-   Orientation:  Rot3(roll=0.0174533 none, pitch=0.0 rad, yaw=0.0 none)
+   Offset:       Vec3(x=1000000.0 nm, y=2000.0 µm, z=None)
+   Orientation:  Rot3(roll=0.0174533 rad, pitch=0.0 rad, yaw=0.0 rad)
    Beam center:  Vec3(x=0.32264 m, y=0.32768 m, z=None)
    Pixel size:   Vec3(x=0.5 cm, y=0.5 cm, z=None)
    Slit length:  None
@@ -41,4 +41,4 @@ Source:
     Min. Wavelength:   2.2 Å
     Max. Wavelength:   10.0 Å
     Wavelength Spread: 14.3 %
-    Beam Size:         BeamSize(name='bm', size=Vec3(x=0.012 m, y=13000.0 none, z=None))
+    Beam Size:         BeamSize(name='bm', size=Vec3(x=0.012 m, y=13000.0 µm, z=None))

--- a/test/sasdataloader/reference/cansas1d_units.txt
+++ b/test/sasdataloader/reference/cansas1d_units.txt
@@ -41,4 +41,4 @@ Source:
     Min. Wavelength:   2.2 Å
     Max. Wavelength:   10.0 Å
     Wavelength Spread: 14.3 %
-    Beam Size:         BeamSize(name=None, size=None)
+    Beam Size:         BeamSize(name='bm', size=Vec3(x=0.012 m, y=13000.0 none, z=None))

--- a/test/sasdataloader/reference/cansas1d_units.txt
+++ b/test/sasdataloader/reference/cansas1d_units.txt
@@ -1,0 +1,44 @@
+None
+  Q
+  I
+Metadata:
+
+  Test title, Run: 1234
+  =====================
+
+Definition: Test title
+Process:
+    Name: spol
+    Date: 04-Sep-2007 18:35:02
+    Description: None
+    Term: {'radialstep': '10.000', 'sector_width': '4.1416', 'sector_orient': '0.0', 'MASK_file': 'USER:MASK.COM'}
+Process:
+    Name: NCNR-IGOR
+    Date: 03-SEP-2006 11:42:47
+    Description: 
+    Term: {'average_type': 'Circular', 'SAM_file': 'SEP06064.SA3_AJJ_L205', 'BKD_file': 'SEP06064.SA3_AJJ_L205', 'EMP_file': 'SEP06064.SA3_AJJ_L205', 'DIV_file': 'SEP06064.SA3_AJJ_L205', 'MASK_file': 'SEP06064.SA3_AJJ_L205', 'ABS:TSTAND': '1', 'ABS:DSTAND': '1', 'ABS:IZERO': '230.09', 'ABS:XSECT': '1'}
+Sample:
+   ID:           SI600-new-long
+   Transmission: 0.327
+   Thickness:    0.00103 m
+   Temperature:  0.0 K
+   Position:     Vec3(x=10000000.0 nm, y=0.0 mm, z=None)
+   Orientation:  Rot3(roll=0.39269908 rad, pitch=0.00034906585 rad, yaw=None)
+Collimation:
+   Length: 0.123 m
+Detector:
+   Name:         fictional hybrid
+   Distance:     4.15 m
+   Offset:       Vec3(x=1000000.0 nm, y=2000.0 none, z=None)
+   Orientation:  Rot3(roll=0.0174533 none, pitch=0.0 rad, yaw=0.0 none)
+   Beam center:  Vec3(x=0.32264 m, y=0.32768 m, z=None)
+   Pixel size:   Vec3(x=0.5 cm, y=0.5 cm, z=None)
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             disc
+    Wavelength:        0.6 nm
+    Min. Wavelength:   2.2 Å
+    Max. Wavelength:   10.0 Å
+    Wavelength Spread: 14.3 %
+    Beam Size:         BeamSize(name=None, size=None)

--- a/test/sasdataloader/reference/cansas_test.txt
+++ b/test/sasdataloader/reference/cansas_test.txt
@@ -1,4 +1,4 @@
-SasData01
+ILL-D11 example1: 2A 5mM 0%D2O
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/cansas_test.txt
+++ b/test/sasdataloader/reference/cansas_test.txt
@@ -18,6 +18,10 @@ Process:
         Flux_monitor: 1.00
         Count_time: 900.0 s
         Q_resolution: estimated
+    Notes:
+        AvA1 0.0000E+00 AsA2 1.0000E+00 XvA3 1.1111E+01 XsA4 5.2200E-02 XfA5 0.0000E+00
+        S... 13586  0  5.63E+01 2A 5mM 0%D2O    Sbak 13567  0  1.88E+01 H2O buffer
+        Sbak 13533  0  7.49E+00 H2O buffer      V... 13552  1  1.00E+00 Normal 10m from
 Sample:
    ID:           None
    Transmission: 0.0

--- a/test/sasdataloader/reference/cansas_test.txt
+++ b/test/sasdataloader/reference/cansas_test.txt
@@ -11,7 +11,13 @@ Process:
     Name: spol
     Date: 04-Sep-2007 18:12:27
     Description: None
-    Term: {'radialstep': '10.000', 'sector_width': '180.0', 'sector_orient': '0.0', 'Flux_monitor': '1.00', 'Count_time': '900.000', 'Q_resolution': 'estimated'}
+    Terms:
+        radialstep: 10.0 mm
+        sector_width: 180.0 deg
+        sector_orient: 0.0 deg
+        Flux_monitor: 1.00
+        Count_time: 900.0 s
+        Q_resolution: estimated
 Sample:
    ID:           None
    Transmission: 0.0

--- a/test/sasdataloader/reference/cansas_test.txt
+++ b/test/sasdataloader/reference/cansas_test.txt
@@ -1,4 +1,4 @@
-None
+SasData01
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/cansas_test.txt
+++ b/test/sasdataloader/reference/cansas_test.txt
@@ -36,4 +36,4 @@ Source:
     Min. Wavelength:   None
     Max. Wavelength:   None
     Wavelength Spread: 0.0 Å
-    Beam Size:         BeamSize(name=None, size=None)
+    Beam Size:         BeamSize(name=None, size=Vec3(x=30.0 mm, y=0.0 mm, z=None))

--- a/test/sasdataloader/reference/cansas_test.txt
+++ b/test/sasdataloader/reference/cansas_test.txt
@@ -1,0 +1,39 @@
+None
+  Q
+  I
+Metadata:
+
+  ILL-D11 example1: 2A 5mM 0%D2O, Run: g013586.001
+  ================================================
+
+Definition: ILL-D11 example1: 2A 5mM 0%D2O
+Process:
+    Name: spol
+    Date: 04-Sep-2007 18:12:27
+    Description: None
+    Term: {'radialstep': '10.000', 'sector_width': '180.0', 'sector_orient': '0.0', 'Flux_monitor': '1.00', 'Count_time': '900.000', 'Q_resolution': 'estimated'}
+Sample:
+   ID:           None
+   Transmission: 0.0
+   Thickness:    0.0 mm
+   Temperature:  32.0 K
+   Position:     Vec3(x=10.0 mm, y=0.0 mm, z=None)
+   Orientation:  Rot3(roll=0.02 deg, pitch=None, yaw=None)
+Collimation:
+   Length: None
+Detector:
+   Name:         
+   Distance:     10.0 m
+   Offset:       None
+   Orientation:  Rot3(roll=0.0 deg, pitch=None, yaw=None)
+   Beam center:  Vec3(x=311.0 mm, y=315.0 mm, z=None)
+   Pixel size:   Vec3(x=10.0 mm, y=10.0 mm, z=None)
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        6.0 Å
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 0.0 Å
+    Beam Size:         BeamSize(name=None, size=None)

--- a/test/sasdataloader/reference/cansas_test_modified.txt
+++ b/test/sasdataloader/reference/cansas_test_modified.txt
@@ -11,7 +11,13 @@ Process:
     Name: spol
     Date: 04-Sep-2007 18:12:27
     Description: None
-    Term: {'radialstep': '10.000', 'sector_width': '180.0', 'sector_orient': '0.0', 'Flux_monitor': '1.00', 'Count_time': '900.000', 'Q_resolution': 'estimated'}
+    Terms:
+        radialstep: 10.0 mm
+        sector_width: 180.0 deg
+        sector_orient: 0.0 deg
+        Flux_monitor: 1.00
+        Count_time: 900.0 s
+        Q_resolution: estimated
 Sample:
    ID:           This is a test file
    Transmission: 0.0

--- a/test/sasdataloader/reference/cansas_test_modified.txt
+++ b/test/sasdataloader/reference/cansas_test_modified.txt
@@ -1,4 +1,4 @@
-SasData01
+ILL-D11 example1: 2A 5mM 0%D2O
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/cansas_test_modified.txt
+++ b/test/sasdataloader/reference/cansas_test_modified.txt
@@ -18,6 +18,10 @@ Process:
         Flux_monitor: 1.00
         Count_time: 900.0 s
         Q_resolution: estimated
+    Notes:
+        AvA1 0.0000E+00 AsA2 1.0000E+00 XvA3 1.1111E+01 XsA4 5.2200E-02 XfA5 0.0000E+00
+        S... 13586  0  5.63E+01 2A 5mM 0%D2O    Sbak 13567  0  1.88E+01 H2O buffer
+        Sbak 13533  0  7.49E+00 H2O buffer      V... 13552  1  1.00E+00 Normal 10m from
 Sample:
    ID:           This is a test file
    Transmission: 0.0

--- a/test/sasdataloader/reference/cansas_test_modified.txt
+++ b/test/sasdataloader/reference/cansas_test_modified.txt
@@ -1,4 +1,4 @@
-None
+SasData01
   Q
   I
 Metadata:

--- a/test/sasdataloader/reference/cansas_test_modified.txt
+++ b/test/sasdataloader/reference/cansas_test_modified.txt
@@ -1,0 +1,39 @@
+None
+  Q
+  I
+Metadata:
+
+  ILL-D11 example1: 2A 5mM 0%D2O, Run: g013586.001
+  ================================================
+
+Definition: ILL-D11 example1: 2A 5mM 0%D2O
+Process:
+    Name: spol
+    Date: 04-Sep-2007 18:12:27
+    Description: None
+    Term: {'radialstep': '10.000', 'sector_width': '180.0', 'sector_orient': '0.0', 'Flux_monitor': '1.00', 'Count_time': '900.000', 'Q_resolution': 'estimated'}
+Sample:
+   ID:           This is a test file
+   Transmission: 0.0
+   Thickness:    0.0 mm
+   Temperature:  32.0 K
+   Position:     Vec3(x=10.0 mm, y=0.0 mm, z=None)
+   Orientation:  Rot3(roll=0.02 deg, pitch=None, yaw=None)
+Collimation:
+   Length: 10.0 m
+Detector:
+   Name:         
+   Distance:     10.0 m
+   Offset:       None
+   Orientation:  Rot3(roll=0.0 deg, pitch=None, yaw=None)
+   Beam center:  Vec3(x=311.0 mm, y=315.0 mm, z=None)
+   Pixel size:   Vec3(x=10.0 mm, y=10.0 mm, z=None)
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        6.0 Å
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 0.0 Å
+    Beam Size:         BeamSize(name=None, size=None)

--- a/test/sasdataloader/reference/cansas_test_modified.txt
+++ b/test/sasdataloader/reference/cansas_test_modified.txt
@@ -36,4 +36,4 @@ Source:
     Min. Wavelength:   None
     Max. Wavelength:   None
     Wavelength Spread: 0.0 Å
-    Beam Size:         BeamSize(name=None, size=None)
+    Beam Size:         BeamSize(name=None, size=Vec3(x=30.0 mm, y=0.0 mm, z=None))

--- a/test/sasdataloader/reference/cansas_xml_multisasentry_multisasdata.txt
+++ b/test/sasdataloader/reference/cansas_xml_multisasentry_multisasdata.txt
@@ -1,0 +1,340 @@
+AF1410:10
+  Q
+  I
+Metadata:
+
+  AF1410-10 (AF1410 steel aged 10 h), Run: ['nuclear sector', 'nuclear+magnetic sector']
+  ===========================================
+
+Definition: AF1410-10 (AF1410 steel aged 10 h)
+Sample:
+   ID:           AF1410-10 (AF1410 steel aged 10 h)
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         area
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        0.85 nm
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 25.0 %
+    Beam Size:         None
+AF1410:1h
+  Q
+  I
+Metadata:
+
+  AF1410-1h (AF1410 steel aged 1 h), Run: ['nuclear sector', 'nuclear+magnetic sector']
+  ==========================================
+
+Definition: AF1410-1h (AF1410 steel aged 1 h)
+Sample:
+   ID:           AF1410-1h (AF1410 steel aged 1 h)
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         area
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        0.85 nm
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 25.0 %
+    Beam Size:         None
+AF1410:20
+  Q
+  I
+Metadata:
+
+  AF1410-20 (AF1410 steel aged 20 h), Run: nuclear+magnetic sector
+  ================================================================
+
+Definition: AF1410-20 (AF1410 steel aged 20 h)
+Sample:
+   ID:           AF1410-20 (AF1410 steel aged 20 h)
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         area
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        0.85 nm
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 25.0 %
+    Beam Size:         None
+AF1410:2h
+  Q
+  I
+Metadata:
+
+  AF1410-2h (AF1410 steel aged 2 h), Run: ['nuclear sector', 'nuclear+magnetic sector']
+  ==========================================
+
+Definition: AF1410-2h (AF1410 steel aged 2 h)
+Sample:
+   ID:           AF1410-2h (AF1410 steel aged 2 h)
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         area
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        0.85 nm
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 25.0 %
+    Beam Size:         None
+AF1410:50
+  Q
+  I
+Metadata:
+
+  AF1410-50 (AF1410 steel aged 50 h), Run: ['nuclear sector', 'nuclear+magnetic sector']
+  ===========================================
+
+Definition: AF1410-50 (AF1410 steel aged 50 h)
+Sample:
+   ID:           AF1410-50 (AF1410 steel aged 50 h)
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         area
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        0.85 nm
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 25.0 %
+    Beam Size:         None
+AF1410:5h
+  Q
+  I
+Metadata:
+
+  AF1410-5h (AF1410 steel aged 5 h), Run: ['nuclear sector', 'nuclear+magnetic sector']
+  ==========================================
+
+Definition: AF1410-5h (AF1410 steel aged 5 h)
+Sample:
+   ID:           AF1410-5h (AF1410 steel aged 5 h)
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         area
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        0.85 nm
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 25.0 %
+    Beam Size:         None
+AF1410:8h
+  Q
+  I
+Metadata:
+
+  AF1410-8h (AF1410 steel aged 8 h), Run: ['nuclear sector', 'nuclear+magnetic sector']
+  ==========================================
+
+Definition: AF1410-8h (AF1410 steel aged 8 h)
+Sample:
+   ID:           AF1410-8h (AF1410 steel aged 8 h)
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         area
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        0.85 nm
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 25.0 %
+    Beam Size:         None
+AF1410:cc
+  Q
+  I
+Metadata:
+
+  AF1410-cc (AF1410 steel aged 100 h), Run: ['nuclear sector', 'nuclear+magnetic sector']
+  ============================================
+
+Definition: AF1410-cc (AF1410 steel aged 100 h)
+Sample:
+   ID:           AF1410-cc (AF1410 steel aged 100 h)
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         area
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        0.85 nm
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 25.0 %
+    Beam Size:         None
+AF1410:hf
+  Q
+  I
+Metadata:
+
+  AF1410-hf (AF1410 steel aged 0.5 h), Run: ['nuclear sector', 'nuclear+magnetic sector']
+  ============================================
+
+Definition: AF1410-hf (AF1410 steel aged 0.5 h)
+Sample:
+   ID:           AF1410-hf (AF1410 steel aged 0.5 h)
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         area
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        0.85 nm
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 25.0 %
+    Beam Size:         None
+AF1410:qu
+  Q
+  I
+Metadata:
+
+  AF1410-qu (AF1410 steel aged 0.25 h), Run: ['nuclear sector', 'nuclear+magnetic sector']
+  =============================================
+
+Definition: AF1410-qu (AF1410 steel aged 0.25 h)
+Sample:
+   ID:           AF1410-qu (AF1410 steel aged 0.25 h)
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         area
+   Distance:     None
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         neutron
+    Shape:             None
+    Wavelength:        0.85 nm
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: 25.0 %
+    Beam Size:         None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasdata.txt
@@ -9,7 +9,6 @@ Process:
     Name: Mantid generated CanSAS1D XML
     Date: 11-May-2016 12:15:34
     Description: None
-    Term: None
 Sample:
    ID:           
    Transmission: None

--- a/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
+++ b/test/sasdataloader/reference/nxcansas_1Dand2D_multisasentry.txt
@@ -9,7 +9,6 @@ Process:
     Name: Mantid generated CanSAS1D XML
     Date: 11-May-2016 12:15:34
     Description: None
-    Term: None
 Sample:
    ID:           
    Transmission: None
@@ -54,7 +53,6 @@ Process:
     Name: Mantid generated CanSAS1D XML
     Date: 11-May-2016 12:15:34
     Description: None
-    Term: None
 Sample:
    ID:           
    Transmission: None

--- a/test/sasdataloader/reference/valid_cansas_xml.txt
+++ b/test/sasdataloader/reference/valid_cansas_xml.txt
@@ -11,7 +11,9 @@ Process:
     Name: Mantid generated CanSAS1D XML
     Date: 10-Oct-2013 16:00:29
     Description: None
-    Term: {'svn': '2.6.20130902.1504', 'user_file': 'K:/masks/MASKLOQ_MAN_133D_Xpress_8mm.txt'}
+    Terms:
+        svn: 2.6.20130902.1504
+        user_file: K:/masks/MASKLOQ_MAN_133D_Xpress_8mm.txt
 Sample:
    ID:           LOQ_Standard_TK49_SANS
    Transmission: None

--- a/test/sasdataloader/reference/valid_cansas_xml.txt
+++ b/test/sasdataloader/reference/valid_cansas_xml.txt
@@ -1,0 +1,47 @@
+80514main_1D_2.2_10.0
+  Q
+  I
+Metadata:
+
+  LOQ_Standard_TK49_SANS, Run: 80514
+  ==================================
+
+Definition: LOQ_Standard_TK49_SANS
+Process:
+    Name: Mantid generated CanSAS1D XML
+    Date: 10-Oct-2013 16:00:29
+    Description: None
+    Term: {'svn': '2.6.20130902.1504', 'user_file': 'K:/masks/MASKLOQ_MAN_133D_Xpress_8mm.txt'}
+Sample:
+   ID:           LOQ_Standard_TK49_SANS
+   Transmission: None
+   Thickness:    None
+   Temperature:  None
+   Position:     None
+   Orientation:  None
+Collimation:
+   Length: None
+Detector:
+   Name:         HAB
+   Distance:     0.579 m
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Detector:
+   Name:         main-detector-bank
+   Distance:     4.14902 m
+   Offset:       None
+   Orientation:  None
+   Beam center:  None
+   Pixel size:   None
+   Slit length:  None
+Source:
+    Radiation:         Spallation Neutron Source
+    Shape:             None
+    Wavelength:        None
+    Min. Wavelength:   None
+    Max. Wavelength:   None
+    Wavelength Spread: None
+    Beam Size:         None

--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -40,7 +40,7 @@ test_xml_file_names = [
     "cansas1d_badunits",
     "cansas1d_notitle",
     "cansas1d_slit",
-    # "cansas1d_units",
+    "cansas1d_units",
     "cansas_test",
     "cansas_test_modified",
     "cansas_xml_multisasentry_multisasdata",

--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -38,12 +38,12 @@ test_xml_file_names = [
     "TestExtensions",
     "cansas1d",
     # "cansas1d_badunits",
-    # "cansas1d_notitle",
-    # "cansas1d_slit",
+    "cansas1d_notitle",
+    "cansas1d_slit",
     # "cansas1d_units",
-    # "cansas_test",
-    # "cansas_test_modified",
-    # "cansas_xml_multisasentry_multisasdata",
+    "cansas_test",
+    "cansas_test_modified",
+    "cansas_xml_multisasentry_multisasdata",
     "valid_cansas_xml",
 ]
 

--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -19,14 +19,32 @@ from sasdata.dataloader.data_info import Data1D, Data2D
 from sasdata.dataloader.readers.xml_reader import XMLreader
 from sasdata.dataloader.readers.cansas_reader import Reader
 from sasdata.dataloader.readers.cansas_constants import CansasConstants
-from sasdata.temp_hdf5_reader import load_data
+from sasdata.temp_hdf5_reader import load_data as hdf_load_data
+from sasdata.temp_xml_reader import load_data as xml_load_data
 
-test_file_names = [
+test_hdf_file_names = [
     # "simpleexamplefile",
     "nxcansas_1Dand2D_multisasentry",
     "nxcansas_1Dand2D_multisasdata",
     "MAR07232_rest",
     "x25000_no_di",
+]
+
+test_xml_file_names = [
+    "ISIS_1_0",
+    "ISIS_1_1",
+    "ISIS_1_1_doubletrans",
+    "ISIS_1_1_notrans",
+    "TestExtensions",
+    # "cansas1d",
+    # "cansas1d_badunits",
+    # "cansas1d_notitle",
+    # "cansas1d_slit",
+    # "cansas1d_units",
+    # "cansas_test",
+    # "cansas_test_modified",
+    # "cansas_xml_multisasentry_multisasdata",
+    "valid_cansas_xml",
 ]
 
 
@@ -36,9 +54,20 @@ def local_load(path: str):
 
 
 @pytest.mark.sasdata
-@pytest.mark.parametrize("f", test_file_names)
-def test_load_file(f):
-    data = load_data(local_load(f"data/{f}.h5"))
+@pytest.mark.parametrize("f", test_hdf_file_names)
+def test_hdf_load_file(f):
+    data = hdf_load_data(local_load(f"data/{f}.h5"))
+
+    with open(local_load(f"reference/{f}.txt")) as infile:
+        expected = "".join(infile.readlines())
+    keys = sorted([d for d in data])
+    assert "".join(data[k].summary() for k in keys) == expected
+
+
+@pytest.mark.sasdata
+@pytest.mark.parametrize("f", test_xml_file_names)
+def test_xml_load_file(f):
+    data = xml_load_data(local_load(f"data/{f}.xml"))
 
     with open(local_load(f"reference/{f}.txt")) as infile:
         expected = "".join(infile.readlines())

--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -36,7 +36,7 @@ test_xml_file_names = [
     "ISIS_1_1_doubletrans",
     "ISIS_1_1_notrans",
     "TestExtensions",
-    # "cansas1d",
+    "cansas1d",
     # "cansas1d_badunits",
     # "cansas1d_notitle",
     # "cansas1d_slit",

--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -37,7 +37,7 @@ test_xml_file_names = [
     "ISIS_1_1_notrans",
     "TestExtensions",
     "cansas1d",
-    # "cansas1d_badunits",
+    "cansas1d_badunits",
     "cansas1d_notitle",
     "cansas1d_slit",
     # "cansas1d_units",

--- a/test/utest_unit_parser.py
+++ b/test/utest_unit_parser.py
@@ -9,6 +9,7 @@ named_units_for_testing = [
     ('A-1', units.per_angstrom),
     ('1/A', units.per_angstrom),
     ('1/angstroms', units.per_angstrom),
+    ('micron', units.micrometers),
     ('kmh-2', units.kilometers_per_square_hour),
     ('km/h2', units.kilometers_per_square_hour),
     ('kgm/s2', units.newtons),

--- a/test/utest_unit_parser.py
+++ b/test/utest_unit_parser.py
@@ -9,6 +9,7 @@ named_units_for_testing = [
     ('A-1', units.per_angstrom),
     ('1/A', units.per_angstrom),
     ('1/angstroms', units.per_angstrom),
+    ('micrometer', units.micrometers),
     ('micron', units.micrometers),
     ('kmh-2', units.kilometers_per_square_hour),
     ('km/h2', units.kilometers_per_square_hour),


### PR DESCRIPTION
This adds XML parsers for CanSAS data to the new SasData format.  I've included a test to check for regressions.  While the parser is specifically setup to continue on the the event that it encounters unknown units (with a suitable warning for the user to ensure that they are aware of the issue), I have also made some small changes to the units parser to enable it to handle "microns" and "micrometer", both of which occured during tests, felt faily common, and previously caused unit parsing to fail.