### PR TITLE
Fix unit tests on refactor branch

### DIFF
--- a/sasdata/quantities/_units_base.py
+++ b/sasdata/quantities/_units_base.py
@@ -295,10 +295,12 @@ class NamedUnit(Unit):
         """Match other units exactly or match strings against ANY of our names"""
         match other:
             case str():
-                return self.name == other or self.ascii_symbol == other or self.symbol == other
+                return self.name == other or self.name == f"{other}s" or self.ascii_symbol == other or self.symbol == other
             case NamedUnit():
                 return self.name == other.name \
                     and self.ascii_symbol == other.ascii_symbol and self.symbol == other.symbol
+            case Unit():
+                return self.equivalent(other) and np.abs(np.log(self.scale/other.scale)) < 1e-5
             case _:
                 return False
 

--- a/sasdata/quantities/unit_parser.py
+++ b/sasdata/quantities/unit_parser.py
@@ -49,7 +49,7 @@ def parse_single_unit(unit_str: str, unit_group: UnitGroup | None = None, longes
     matching_types = [unit for symbol, unit in lookup_dict.items()
                       if symbol == current_unit or unit == current_unit]
     if not matching_types:
-        raise ValueError(f"No known type matching {current_unit}")
+        raise KeyError(f"No known type matching {current_unit}")
     final_unit = matching_types[0]
     remaining_str = unit_str[string_pos::]
     return final_unit, remaining_str

--- a/sasdata/quantities/units.py
+++ b/sasdata/quantities/units.py
@@ -383,6 +383,8 @@ class NamedUnit(Unit):
             case NamedUnit():
                 return self.name == other.name \
                     and self.ascii_symbol == other.ascii_symbol and self.symbol == other.symbol
+            case Unit():
+                return self.equivalent(other) and np.abs(np.log(self.scale/other.scale)) < 1e-5
             case _:
                 return False
 

--- a/sasdata/temp_ascii_reader.py
+++ b/sasdata/temp_ascii_reader.py
@@ -1,12 +1,11 @@
 from sasdata.ascii_reader_metadata import AsciiMetadataCategory, AsciiReaderMetadata, pairings, bidirectional_pairings
 from sasdata.data import SasData
-from sasdata.dataset_types import DatasetType, one_dim
+from sasdata.dataset_types import DatasetType, one_dim, unit_kinds
 from sasdata.guess import guess_column_count, guess_columns, guess_starting_position
 from sasdata.quantities.units import NamedUnit
-from sasdata.quantities.quantity import NamedQuantity, Quantity
-from sasdata.quantities.accessors import AccessorTarget, Group
-from sasdata.metadata import Metadata
-from sasdata.data_backing import Dataset, Group
+from sasdata.quantities.quantity import Quantity
+from sasdata.quantities.accessors import Group
+from sasdata.data_backing import Dataset 
 from enum import Enum
 from dataclasses import dataclass, field
 import numpy as np
@@ -51,7 +50,7 @@ class AsciiReaderParams:
 
     @property
     def columns_included(self) -> list[tuple[str, NamedUnit]]:
-        return [column for column in self.columns if column[0] == '<ignore>' and isinstance(column[1], NamedUnit)]
+        return [column for column in self.columns if column[0] != '<ignore>' and isinstance(column[1], NamedUnit)]
 
 # TODO: Should I make this work on a list of filenames as well?
 def guess_params_from_filename(filename: str, dataset_type: DatasetType) -> AsciiReaderParams:
@@ -63,7 +62,7 @@ def guess_params_from_filename(filename: str, dataset_type: DatasetType) -> Asci
         lines_split = [split_line(separator_dict, line) for line in lines]
         startpos = guess_starting_position(lines_split)
         colcount = guess_column_count(lines_split, startpos)
-        columns = guess_columns(colcount, dataset_type)
+        columns = [(x, unit_kinds[x]) for x in guess_columns(colcount, dataset_type) if x in unit_kinds]
         params = AsciiReaderParams([filename], columns, starting_line=startpos, separator_dict=separator_dict)
         return params
 
@@ -113,7 +112,7 @@ def load_quantities(params: AsciiReaderParams, filename: str) -> dict[str, Quant
                 # should be ignored entirely.
                 print(f'Line {i + 1} skipped.')
                 continue
-    file_quantities = {name: Quantity(arrays[i], unit) for i, (name, unit) in enumerate(params.columns) }
+    file_quantities = {name: Quantity(arrays[i], unit) for i, (name, unit) in enumerate(params.columns_included) }
     return file_quantities
 
 def metadata_to_data_backing(metadata: dict[str, AsciiMetadataCategory[str]]) -> Group:

--- a/sasdata/trend.py
+++ b/sasdata/trend.py
@@ -76,10 +76,12 @@ class Trend:
                     continue
                 new_quantities[name] = quantity @ mat
 
-            new_datum = SasData(datum.name,
-                                new_quantities,
-                                datum.dataset_type,
-                                datum._raw_metadata)
+            new_datum = SasData(
+                name=datum.name,
+                data_contents=new_quantities,
+                dataset_type=datum.dataset_type,
+                metadata=datum.metadata,
+            )
             new_data.append(new_datum)
         new_trend = Trend(new_data,
                           self.trend_axis)

--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -61,7 +61,7 @@ def local_load(path: str):
 def test_hdf_load_file(f):
     data = hdf_load_data(local_load(f"data/{f}.h5"))
 
-    with open(local_load(f"reference/{f}.txt")) as infile:
+    with open(local_load(f"reference/{f}.txt"), encoding="utf-8") as infile:
         expected = "".join(infile.readlines())
     keys = sorted([d for d in data])
     assert "".join(data[k].summary() for k in keys) == expected
@@ -72,7 +72,7 @@ def test_hdf_load_file(f):
 def test_xml_load_file(f):
     data = xml_load_data(local_load(f"data/{f}.xml"))
 
-    with open(local_load(f"reference/{f}.txt")) as infile:
+    with open(local_load(f"reference/{f}.txt"), encoding="utf-8") as infile:
         expected = "".join(infile.readlines())
     keys = sorted([d for d in data])
     assert "".join(data[k].summary() for k in keys) == expected

--- a/test/utest_temp_ascii_reader.py
+++ b/test/utest_temp_ascii_reader.py
@@ -27,8 +27,8 @@ def test_ascii_1():
     params.columns = [('Q', per_angstrom), ('I', per_centimeter), ('dI', per_centimeter), ('<ignore>', None), ('<ignore>', None), ('<ignore>', None)]
     loaded_data = load_data(params)[0]
     # Check the first, and last rows to see if they are correct.
-    for datum in loaded_data._data_contents:
-        match datum.name:
+    for name, datum in loaded_data._data_contents.items():
+        match name:
             case 'Q':
                 assert datum.value[0] == pytest.approx(0.002618)
                 assert datum.value[-1] == pytest.approx(0.0497)
@@ -44,8 +44,8 @@ def test_ascii_2():
     params = guess_params_from_filename(filename, one_dim)
     loaded_data = load_data(params)[0]
 
-    for datum in loaded_data._data_contents:
-        match datum.name:
+    for name, datum in loaded_data._data_contents.items():
+        match name:
             case 'Q':
                 assert datum.value[0] == pytest.approx(0)
                 assert datum.value[-1] == pytest.approx(1.22449)


### PR DESCRIPTION
This PR fixes the failing unit tests on the refactor branches.  The commits roughly goes as follow:

# 6d6b90df8f19960b4e2892cf7dae593d3eee2581
I added an extra check in the unit parser a few PRs back, but it through a `ValueError` when the calling function was checking for `KeyError`.  I've modified this code to throw a `KeyError`

# 8dc2c0bcdf2c54a909255173e2b5740def30c905
- The logic of `columns_included` *only* included `<ignore>` columns.  I reversed this to *exclude* `<ignore>` columns
- The columns are expected to be a list of `(name, unit)` but `guess_columns` only returns the names.  I wrapped the call in a list comprehension to return units as well.  I chose to ignore columns with no known unit, but it would also be possible to include those columns, but default them to unitless
- I fixed the quantities to loop over the included columns, instead of all columns, since only the included columns were looped over to form the arrays
- In the unit test itself, `_data_contents` is a dictionary, so I looped over the items and used the key for the matching term

# e3d7998b90e13994517a6295b099d004f4d500a5
`SasData` no longer had a `_raw_metadata` field (the raw metadata is held inside the Metadata object).  I updated the constructor call in `sasdata/trend.py` to remove the extra parameter

# 89e96eeedde67d77262fdad514ffdc3da6db0186
I updated the equality operator on `NamedUnit` to support comparison with unnamed `Unit` objects. I also fixed an instance where `units.py` had been edited directly instead of being generated from `_units_base.py`

# 1f488db0b2ebc1473f263da4a7fca17c9984e4a7

Enforce loading the reference files for the unit tests as UTF-8.  On windows, the files are assumed to be UTF-16 by default, which caused the Angstrom symbol to be parsed improperly.  Explicit UTF-8 declaration fixed the issue.