### PR TITLE
Fix version import

### DIFF
--- a/sasdata/__init__.py
+++ b/sasdata/__init__.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 try:
-    from _version import __version__
+    from ._version import __version__
 except ImportError:
     __version__ = "0.0.0.dev"
 


### PR DESCRIPTION
In looking at https://github.com/SasView/sasview/issues/3380, I found that the import of `_version` in sasmodels was incorrect, and that same error is in sasdata. This makes the import relative which ensures that it works as intended.