### PR TITLE
Beginning Modelling requirements

### DIFF
--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -39,9 +39,7 @@ class SasData:
     @property
     def ordinate(self) -> Quantity:
         match self.dataset_type:
-            case dataset_types.one_dim:
-                return self._data_contents["I"]
-            case dataset_types.two_dim:
+            case dataset_types.one_dim | dataset_types.two_dim:
                 return self._data_contents["I"]
             case dataset_types.sesans:
                 return self._data_contents["Depolarisation"]

--- a/sasdata/dataset_types.py
+++ b/sasdata/dataset_types.py
@@ -59,8 +59,11 @@ unit_kinds = {
     "dQx": units.inverse_length,
     "dQy": units.inverse_length,
     "dQz": units.inverse_length,
-    "z": units.length,
-    "G": units.area,
+    "SpinEchoLength": units.length,
+    "Depolarisation": units.inverse_volume,
+    "Wavelength": units.length,
+    "Transmission": units.dimensionless,
+    "Polarisation": units.dimensionless,
     "shadow": units.dimensionless,
     "temperature": units.temperature,
     "magnetic field": units.magnetic_flux_density

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -6,7 +6,6 @@ from typing import Self
 from scipy.special import j0
 
 from sasdata.data import SasData
-from sasdata.metadata import Metadata
 from sasdata.quantities import units
 from sasdata import dataset_types
 from sasdata.quantities.quantity import Operation
@@ -63,22 +62,22 @@ class ComposeRequirements(ModellingRequirements):
 class SesansModel(ModellingRequirements):
     """Perform Hankel transform for SESANS"""
 
-    def preprocess_q(self, SElength: np.ndarray, full_data: SasData) -> np.ndarray:
+    def preprocess_q(self, spin_echo_length: np.ndarray, full_data: SasData) -> np.ndarray:
         """Calculate the q values needed to perform the Hankel transform
 
-        Note: this is undefined for the case when SElengths contains
+        Note: this is undefined for the case when spin_echo_lengths contains
         exactly one element and that values is zero.
 
         """
         # FIXME: Actually do the Hankel transform
-        SElength = np.asarray(SElength)
-        if len(SElength) == 1:
-            q_min, q_max = 0.01 * 2 * pi / SElength[-1], 10 * 2 * pi / SElength[0]
+        spin_echo_length = np.asarray(spin_echo_length)
+        if len(spin_echo_length) == 1:
+            q_min, q_max = 0.01 * 2 * np.pi / spin_echo_length[-1], 10 * 2 * np.pi / spin_echo_length[0]
         else:
             # TODO: Why does q_min depend on the number of correlation lengths?
             # TODO: Why does q_max depend on the correlation step size?
-            q_min = 0.1 * 2 * np.pi / (np.size(SElength) * SElength[-1])
-            q_max = 2 * np.pi / (SElength[1] - SElength[0])
+            q_min = 0.1 * 2 * np.pi / (np.size(spin_echo_length) * spin_echo_length[-1])
+            q_max = 2 * np.pi / (spin_echo_length[1] - spin_echo_length[0])
 
         # TODO: Possibly make this adjustable
         log_spacing = 1.0003
@@ -89,7 +88,7 @@ class SesansModel(ModellingRequirements):
 
         self.H0 = dq / (2 * np.pi) * self.q
 
-        self.H = np.outer(self.q, SElength)
+        self.H = np.outer(self.q, spin_echo_length)
         j0(self.H, out=self.H)
         self.H *= (dq * self.q / (2 * np.pi)).reshape((-1, 1))
 

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -76,6 +76,9 @@ class SmearModel(ModellingRequirements):
 class NullModel(ModellingRequirements):
     """A model that does nothing"""
 
+    def compose(self, other: ModellingRequirements) -> ModellingRequirements:
+        return other
+
     def from_qi_transformation(
         self, data: np.ndarray, _metadata: Metadata
     ) -> np.ndarray:

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -111,3 +111,8 @@ def compose(
 
     """
     return ComposeRequirements(first, second)
+
+
+@compose.register
+def _(second: NullModel, first: ModellingRequirements) -> ModellingRequirements:
+    return first

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -92,7 +92,7 @@ def compose(
 def guess_requirements(data: SasData) -> ModellingRequirements:
     """Use names of axes and units to guess what kind of processing needs to be done"""
     if data.dataset_type == dataset_types.sesans:
-        return SmearModel() + SesansModel()
+        return SesansModel()
     pass
 
 

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -1,23 +1,78 @@
-from dataclasses import dataclass
+from abs import ABC
 
 import numpy as np
 
-from sasdata.metadata import Metadata
+from sasdata.data import SasData
+from sasdata import dataset_types
 from transforms.operation import Operation
 
 
-@dataclass
-class ModellingRequirements:
-    """ Requirements that need to be passed to any modelling step """
+class ModellingRequirements(ABC):
+    """Requirements that need to be passed to any modelling step"""
+
     dimensionality: int
     operation: Operation
 
-    def from_qi_transformation(self, data: np.ndarray, metadata: Metadata) -> np.ndarray:
-        """ Transformation for going from qi to this data"""
+    def __add__(self, other: ModellingRequirements):
+        return compose(self, other)
+
+    @abstractmethod
+    def from_qi_transformation(
+        self, data: np.ndarray, metadata: Metadata
+    ) -> np.ndarray:
+        """Transformation for going from qi to this data"""
         pass
 
 
+class ComposeRequirements(ModellingRequirements):
+    """Composition of two models"""
+
+    first: ModellingRequirements
+    second: ModellingRequirements
+
+    def from_qi_transformation(
+        self, data: np.ndarray, metadata: Metadata
+    ) -> np.ndarray:
+        """Perform both transformations in order"""
+        return self.second.from_qi_transformation(
+            self.first.from_qi_transformation(data, metadata), metadata
+        )
 
 
-def guess_requirements(abscissae, ordinate) -> ModellingRequirements:
-    """ Use names of axes and units to guess what kind of processing needs to be done """
+class SesansModel(ModellingRequirements):
+    """Perform Hankel transform for SESANS"""
+
+    def from_qi_transformation(
+        self, data: np.ndarray, metadata: Metadata
+    ) -> np.ndarray:
+        """Perform Hankel transform"""
+        # FIXME: Actually do the Hankel transform
+       return data
+
+class SmearModel(ModellingRequirements):
+    """Perform a slit smearing"""
+
+    def from_qi_transformation(
+        self, data: np.ndarray, metadata: Metadata
+    ) -> np.ndarray:
+        """Perform smearing transfor"""
+        # FIXME: Actually do the smearing transform
+       return data
+
+class NullModel(ModellingRequirements):
+    """A model that does nothing"""
+
+    def from_qi_transformation(self, data: np.ndarray, _metadata: Metadata) -> np.ndarray:
+        """Do nothing"""
+        return data
+
+def compose(a: ModellingRequirements, b: ModellingRequirements) -> ModellingRequirements:
+    return ComposeRequirements(a, b)
+
+
+
+def guess_requirements(data: SasData) -> ModellingRequirements:
+    """Use names of axes and units to guess what kind of processing needs to be done"""
+    if data.dataset_type == dataset_types.sesans:
+        return SesansModel() + SmearModel()
+    pass

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -173,4 +173,15 @@ def compose(
 
 @compose.register
 def _(second: NullModel, first: ModellingRequirements) -> ModellingRequirements:
+    """Null model is the identity element of composition"""
     return first
+
+
+@compose.register
+def _(second: SesansModel, first: ModellingRequirements) -> ModellingRequirements:
+    match first:
+        case SmearModel():
+            # To the first approximation, there is no slit smearing in SESANS data
+            return second
+        case _:
+            return ComposeRequirements(first, second)

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -49,13 +49,13 @@ class ComposeRequirements(ModellingRequirements):
     def preprocess_q(self, data: np.ndarray, full_data: SasData) -> np.ndarray:
         """Perform both transformations in order"""
         return self.second.preprocess_q(
-            self.first.preprocess_q(data, metadata), metadata
+            self.first.preprocess_q(data, full_data), full_data
         )
 
     def postprocess_iq(self, data: np.ndarray, full_data: SasData) -> np.ndarray:
         """Perform both transformations in order"""
         return self.second.postprocess_iq(
-            self.first.postprocess_iq(data, metadata), metadata
+            self.first.postprocess_iq(data, full_data), full_data
         )
 
 

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -118,9 +118,10 @@ class SesansModel(ModellingRequirements):
         """
         Apply the SESANS transform to the computed I(q)
         """
-        G0 = np.dot(self.H0, data)
-        G = np.dot(self.H.T, data)
+        G0 = self.H0 @ data
+        G = self.H.T @ data
         P = G - G0
+
         return P
 
 

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -21,7 +21,8 @@ class ModellingRequirements(ABC):
 
     @singledispatch
     def compose(self, other: Self) -> Self:
-        return compose(self, other)
+        # Compose uses the reversed order
+        return compose(other, self)
 
     @abstractmethod
     def from_qi_transformation(
@@ -97,6 +98,13 @@ def guess_requirements(data: SasData) -> ModellingRequirements:
 
 @singledispatch
 def compose(
-    first: ModellingRequirements, second: ModellingRequirements
+    second: ModellingRequirements, first: ModellingRequirements
 ) -> ModellingRequirements:
+    """Compose to models together
+
+    This function uses a reverse order so that it can perform dispatch on
+    the *second* term, since the classes already had a chance to dispatch
+    on the first parameter
+
+    """
     return ComposeRequirements(first, second)

--- a/sasdata/quantities/quantity.py
+++ b/sasdata/quantities/quantity.py
@@ -1177,7 +1177,7 @@ class Quantity[QuantityType]:
 
         if variance.units.equivalent(units_squared):
 
-            return self.in_units_of(units), np.sqrt(self.variance.in_units_of(units_squared))
+            return self.in_units_of(units), np.sqrt(self.variance.in_units_of(units_squared).value)
         else:
             raise UnitError(f"Target units ({units}) not compatible with existing units ({variance.units}).")
 

--- a/sasdata/quantities/quantity.py
+++ b/sasdata/quantities/quantity.py
@@ -1177,7 +1177,7 @@ class Quantity[QuantityType]:
 
         if variance.units.equivalent(units_squared):
 
-            return self.in_units_of(units), np.sqrt(self.variance.in_units_of(units_squared).value)
+            return self.in_units_of(units), np.sqrt(self.variance.in_units_of(units_squared))
         else:
             raise UnitError(f"Target units ({units}) not compatible with existing units ({variance.units}).")
 

--- a/sasdata/temp_sesans_reader.py
+++ b/sasdata/temp_sesans_reader.py
@@ -174,10 +174,7 @@ def parse_data(lines: list[str], kvs: dict[str, str]) -> dict[str, Quantity]:
 
         error = None
         if h + "_error" in headers:
-            error = Quantity(
-                value=np.asarray(points[h + "_error"]),
-                units=unit,
-            )
+            error = np.asarray(points[h + "_error"])
 
         data_contents[h] = Quantity(
             value=np.asarray(points[h]),

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -30,7 +30,6 @@ def test_load_file(f):
 
 @pytest.mark.sesans
 def test_sesans_modelling():
-    import matplotlib.pyplot as plt
     data = load_data(local_load("sesans_data/sphere2micron.ses"))
     req = guess_requirements(data)
     assert type(req) is SesansModel
@@ -67,10 +66,6 @@ def test_model_algebra():
     ses = SesansModel()
     sme = SmearModel()
     null = NullModel()
-
-    assert type(ses) is SesansModel
-    assert type(sme) is SmearModel
-    assert type(null) is NullModel
 
     # Ignore slit smearing if we perform a sesans transform afterwards
     assert type(sme + ses) is SesansModel

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -40,6 +40,10 @@ def test_sesans_modelling():
     assert type(sme) is SmearModel
     assert type(null) is NullModel
 
+    # Ignore slit smearing if we perform a sesans transform afterwards
+    assert type(sme + ses) is SesansModel
+    # However, it is possible for the spin echo lengths to have some
+    # smearing between them.
     assert type(ses + sme) is ComposeRequirements
     assert type(null + ses) is SesansModel
     assert type(null + sme) is SmearModel

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -7,8 +7,9 @@ import os
 import pytest
 
 
-from sasdata.temp_sesans_reader import load_data
 from sasdata.model_requirements import guess_requirements, ComposeRequirements, SmearModel, SesansModel, NullModel
+from sasdata.temp_sesans_reader import load_data
+from sasdata.quantities import units, unit_parser
 
 test_file_names = ["sphere2micron", "sphere_isis"]
 
@@ -30,25 +31,34 @@ def test_load_file(f):
 @pytest.mark.sesans
 def test_sesans_modelling():
     import matplotlib.pyplot as plt
-    data = load_data(local_load("sesans_data/sphere_isis.ses"))
+    data = load_data(local_load("sesans_data/sphere2micron.ses"))
     req = guess_requirements(data)
     assert type(req) is SesansModel
 
-    # The Hankel transform of x is -r^-3
-    x = np.arange(0.0, len(data._data_contents["Wavelength"].value))
-    inner_q = req.preprocess_q(x, data)
-    # Just use y=1/x as our model
-    iq = inner_q[:]**-1.0
-    result = req.postprocess_iq(iq, data)
 
-    # plt.loglog()
-    # plt.plot(x, 1/(2 * np.pi) * x**-1, label="Expected")
-    # plt.plot(x, result, label="Computed")
-    # plt.legend(loc=0)
-    # plt.show()
-    assert x.shape == result.shape
-    for (expected, computed) in zip(-x**-3, result):
-        assert expected == computed
+    def sphere(qr):
+        def sas_3j1x_x(x):
+            return (np.sin(x) - x * np.cos(x))/x**3
+        def form_volume(x):
+            return np.pi * 4.0 / 3.0 * x**3
+        radius = 10000 # 1 micron
+
+        bes = sas_3j1x_x(q*radius)
+        contrast = 5.4e-7 # Contrast is hard coded for best fit
+        form = contrast * form_volume(radius) * bes
+        f2 = 1.0e-4*form*form
+        return f2
+
+    # The Hankel transform of x is -r^-3
+    x = data._data_contents["SpinEchoLength"].in_units_of(units.angstroms)
+    q = req.preprocess_q(x, data)
+    result = req.postprocess_iq(sphere(q), data)
+
+    y, yerr = data._data_contents["Depolarisation"].in_units_of_with_standard_error(unit_parser.parse("A-2 cm-1"))
+    assert y.shape == result.shape
+
+    xi_squared = np.sum( ((y - result) / yerr)**2 ) / len(y)
+    assert 1.0 < xi_squared < 1.5
 
 
 

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -7,6 +7,7 @@ import pytest
 
 
 from sasdata.temp_sesans_reader import load_data
+from sasdata.model_requirements import guess_requirements, ComposeRequirements
 
 test_file_names = ["sphere2micron", "sphere_isis"]
 
@@ -24,3 +25,9 @@ def test_load_file(f):
     with open(local_load(f"reference/{f}.txt")) as infile:
         expected = "".join(infile.readlines())
     assert data.summary() == expected
+
+@pytest.mark.sesans
+def test_sesans_modelling():
+    data = load_data(local_load("sesans_data/sphere_isis.ses"))
+    req = guess_requirements(data)
+    assert type(guess_requirements(data)) is ComposeRequirements

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -30,7 +30,8 @@ def test_load_file(f):
 def test_sesans_modelling():
     data = load_data(local_load("sesans_data/sphere_isis.ses"))
     req = guess_requirements(data)
-    assert type(guess_requirements(data)) is ComposeRequirements
+    assert type(guess_requirements(data)) is SesansModel
+
     ses = SesansModel()
     sme = SmearModel()
     null = NullModel()

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -7,7 +7,7 @@ import pytest
 
 
 from sasdata.temp_sesans_reader import load_data
-from sasdata.model_requirements import guess_requirements, ComposeRequirements
+from sasdata.model_requirements import guess_requirements, ComposeRequirements, SmearModel, SesansModel, NullModel
 
 test_file_names = ["sphere2micron", "sphere_isis"]
 
@@ -31,3 +31,16 @@ def test_sesans_modelling():
     data = load_data(local_load("sesans_data/sphere_isis.ses"))
     req = guess_requirements(data)
     assert type(guess_requirements(data)) is ComposeRequirements
+    ses = SesansModel()
+    sme = SmearModel()
+    null = NullModel()
+
+    assert type(ses) is SesansModel
+    assert type(sme) is SmearModel
+    assert type(null) is NullModel
+
+    assert type(ses + sme) is ComposeRequirements
+    assert type(null + ses) is SesansModel
+    assert type(null + sme) is SmearModel
+    assert type(ses + null) is SesansModel
+    assert type(sme + null) is SmearModel

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -30,8 +30,15 @@ def test_load_file(f):
 def test_sesans_modelling():
     data = load_data(local_load("sesans_data/sphere_isis.ses"))
     req = guess_requirements(data)
-    assert type(guess_requirements(data)) is SesansModel
+    assert type(req) is SesansModel
 
+    inner_q = req.preprocess_q(data.abscissae.value, data)
+    req.postprocess_iq(inner_q, data.metadata)
+
+
+
+@pytest.mark.sesans
+def test_model_algebra():
     ses = SesansModel()
     sme = SmearModel()
     null = NullModel()


### PR DESCRIPTION
This is some preliminary work on adding support for Modelling requirements.  The following is now supported:

- The `ModellingRequirements` has been fleshed out and subclassed, including dispatch methods to help intelligently combine complex requireents into simpler ones
- The SESANS smearing implemented with corresponding unit test
- Performing a smear *before* a SESANS model is ignored, since SESANS insensitive to Q smearing
- Fixed a small bug in getting the uncertainty of a quantity in alternate units

This PR does *not* implement pinhole smearing or slit smearing, nor does it attempt to guess the requirements of Q-based data.  I can hold off on the PR until those are implemented, but I thought it might be useful to get some eyes on this work before I head too far in a possibly bad direction.