### PR TITLE
Fix ASCII reader column guesses

### DIFF
--- a/sasdata/default_units.py
+++ b/sasdata/default_units.py
@@ -5,11 +5,12 @@ import sasdata.quantities.units as unit
 from sasdata.dataset_types import unit_kinds
 
 default_units = {
-    'Q': [unit.per_nanometer, unit.per_angstrom, unit.per_meter],
-    'I': [unit.per_centimeter, unit.per_meter],
-    'dQ': 'Q',
-    'dI': 'I'
+    "Q": [unit.per_nanometer, unit.per_angstrom, unit.per_meter],
+    "I": [unit.per_centimeter, unit.per_meter],
+    "dQ": "Q",
+    "dI": "I",
 }
+
 
 def defaults_or_fallback(column_name: str) -> list[NamedUnit]:
     value = default_units.get(column_name, unit_kinds[column_name].units)
@@ -17,5 +18,13 @@ def defaults_or_fallback(column_name: str) -> list[NamedUnit]:
         return defaults_or_fallback(value)
     return value
 
+
 def first_default_for_fallback(column_name: str) -> NamedUnit:
     return defaults_or_fallback(column_name)[0]
+
+
+def get_default_unit(column_name: str, unit_group: unit.UnitGroup):
+    value = first_default_for_fallback(column_name)
+    # Fallback to the first unit in the unit group if we don't have a default registered.
+    if value is None:
+        return unit_group.units[0]

--- a/sasdata/default_units.py
+++ b/sasdata/default_units.py
@@ -28,3 +28,4 @@ def get_default_unit(column_name: str, unit_group: unit.UnitGroup):
     # Fallback to the first unit in the unit group if we don't have a default registered.
     if value is None:
         return unit_group.units[0]
+    return value

--- a/sasdata/temp_ascii_reader.py
+++ b/sasdata/temp_ascii_reader.py
@@ -12,6 +12,7 @@ from sasdata.guess import (
     guess_starting_position,
     guess_dataset_type,
 )
+from sasdata.default_units import get_default_unit
 from sasdata.quantities.units import NamedUnit
 from sasdata.quantities.quantity import Quantity
 from sasdata.metadata import MetaNode, Metadata
@@ -82,7 +83,7 @@ def guess_params_from_filename(
         startpos = guess_starting_position(lines_split)
         colcount = guess_column_count(lines_split, startpos)
         columns = [
-            (x, unit_kinds[x])
+            (x, get_default_unit(x))
             for x in guess_columns(colcount, dataset_type)
             if x in unit_kinds
         ]

--- a/sasdata/temp_ascii_reader.py
+++ b/sasdata/temp_ascii_reader.py
@@ -88,7 +88,11 @@ def guess_params_from_filename(
             if x in unit_kinds
         ]
         params = AsciiReaderParams(
-            [filename], columns, starting_line=startpos, separator_dict=separator_dict
+            [filename],
+            columns,
+            starting_line=startpos,
+            separator_dict=separator_dict,
+            dataset_type=guess_dataset_type(filename),
         )
         return params
 

--- a/sasdata/temp_ascii_reader.py
+++ b/sasdata/temp_ascii_reader.py
@@ -83,7 +83,7 @@ def guess_params_from_filename(
         startpos = guess_starting_position(lines_split)
         colcount = guess_column_count(lines_split, startpos)
         columns = [
-            (x, get_default_unit(x))
+            (x, get_default_unit(x, unit_kinds[x]))
             for x in guess_columns(colcount, dataset_type)
             if x in unit_kinds
         ]

--- a/test/utest_temp_ascii_reader.py
+++ b/test/utest_temp_ascii_reader.py
@@ -49,6 +49,7 @@ def test_ascii_1():
         ("<ignore>", None),
     ]
     loaded_data = load_data(params)[0]
+    assert len(loaded_data._data_contents) > 0
     # Check the first, and last rows to see if they are correct.
     for name, datum in loaded_data._data_contents.items():
         match name:
@@ -66,7 +67,7 @@ def test_ascii_1():
 def test_ascii_2():
     filename = find("test_3_columns.txt", "sasdataloader")
     loaded_data = load_data_default_params(filename)[0]
-
+    assert len(loaded_data._data_contents) > 0
     for name, datum in loaded_data._data_contents.items():
         match name:
             case "Q":
@@ -84,6 +85,7 @@ def test_ascii_2d():
     filename = find("detector_rectangular.DAT", "sasdataloader")
     # Make sure that the dataset type is guessed as 2D data.
     loaded_data = load_data_default_params(filename)[0]
+    assert len(loaded_data._data_contents) > 0
 
     for name, datum in loaded_data._data_contents.items():
         match name:

--- a/test/utest_temp_ascii_reader.py
+++ b/test/utest_temp_ascii_reader.py
@@ -81,6 +81,9 @@ def test_ascii_2():
                 assert datum.value[-1] == pytest.approx(1.05918)
 
 
+@pytest.mark.xfail(
+    reason="Guesses for 2D ASCII files are currently wrong, so the data loaded won't be correct."
+)
 def test_ascii_2d():
     filename = find("detector_rectangular.DAT", "sasdataloader")
     # Make sure that the dataset type is guessed as 2D data.


### PR DESCRIPTION
This PR adds a fix to the ASCII tests so that they fail when no data is loaded. This is temporary solution until the unit test refactor has been completed.

There was an issue where guessed columns would have their unit set to the unit *group* rather than an *individual* unit. This PR introduces some rudimentary logic for guessing a default unit, but this can be expanded on in the future.

After fixing the ASCII test, a separate bug has been uncovered where 2D ASCII files can't be loaded because the reader can't currently guess where the data starts from properly. This has been marked as an expected fail, and will be fixed in a separate PR.