### PR TITLE
Add PyPi publishing step to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,3 +79,23 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest -v -s test
+
+  publish-to-pypi:
+    name: Publish to pypi
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sasdata
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
     name: Publish to pypi
     if: startsWith(github.ref, 'refs/tags/')
     needs:
-      - build
+      - unit-test
     runs-on: ubuntu-latest
     environment:
       name: pypi


### PR DESCRIPTION
This adds automated pypi publishing to the github workflow.

Currently untested, but I could create a temp tag to see if it works.