### PR TITLE
Refactor Q-smearing models

### DIFF
--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -258,7 +258,7 @@ def _(second: NullModel, first: ModellingRequirements) -> ModellingRequirements:
 @compose.register
 def _(second: SesansModel, first: ModellingRequirements) -> ModellingRequirements:
     match first:
-        case PinholeModel():
+        case PinholeModel() | SlitModel():
             # To the first approximation, there is no slit smearing in SESANS data
             return second
         case _:

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -32,7 +32,7 @@ class ModellingRequirements(ABC):
         pass
 
     @abstractmethod
-    def postprocess_iq(self, data: Quantity[np.ndarray], full_data: SasData) -> np.ndarray:
+    def postprocess_iq(self, data: np.ndarray, full_data: SasData) -> np.ndarray:
         """Transform the I(Q) values after running the model"""
         pass
 
@@ -53,7 +53,7 @@ class ComposeRequirements(ModellingRequirements):
             self.first.preprocess_q(data, full_data), full_data
         )
 
-    def postprocess_iq(self, data: Quantity[np.ndarray], full_data: SasData) -> np.ndarray:
+    def postprocess_iq(self, data: np.ndarray, full_data: SasData) -> np.ndarray:
         """Perform both transformations in order"""
         return self.second.postprocess_iq(
             self.first.postprocess_iq(data, full_data), full_data
@@ -114,7 +114,7 @@ class SesansModel(ModellingRequirements):
 
         return self.q
 
-    def postprocess_iq(self, data: Quantity[np.ndarray], full_data: SasData) -> np.ndarray:
+    def postprocess_iq(self, data: np.ndarray, full_data: SasData) -> np.ndarray:
         """
         Apply the SESANS transform to the computed I(q)
         """
@@ -133,7 +133,7 @@ class SmearModel(ModellingRequirements):
         # FIXME: Actually do the smearing transform
         return data
 
-    def postprocess_iq(self, data: Quantity[np.ndarray], full_data: SasData) -> np.ndarray:
+    def postprocess_iq(self, data: np.ndarray, full_data: SasData) -> np.ndarray:
         """Perform smearing transform"""
         # FIXME: Actually do the smearing transform
         return data
@@ -149,7 +149,7 @@ class NullModel(ModellingRequirements):
         """Do nothing"""
         return data
 
-    def postprocess_iq(self, data: Quantity[np.ndarray], _full_data: SasData) -> np.ndarray:
+    def postprocess_iq(self, data: np.ndarray, _full_data: SasData) -> np.ndarray:
         """Do nothing"""
         return data
 

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -477,11 +477,8 @@ def slit_resolution(q_calc, q, width, length, n_length=30):
 
     """
 
-    # np.set_printoptions(precision=6, linewidth=10000)
-
     # The current algorithm is a midpoint rectangle rule.
     q_edges = bin_edges(q_calc)  # Note: requires q > 0
-    # q_edges[q_edges < 0.0] = 0.0 # clip edges below zero
     weights = np.zeros((len(q), len(q_calc)), "d")
 
     # print(q_calc)

--- a/sasdata/model_requirements.py
+++ b/sasdata/model_requirements.py
@@ -63,7 +63,9 @@ class ComposeRequirements(ModellingRequirements):
 class SesansModel(ModellingRequirements):
     """Perform Hankel transform for SESANS"""
 
-    def preprocess_q(self, spin_echo_length: np.ndarray, full_data: SasData) -> np.ndarray:
+    def preprocess_q(
+        self, spin_echo_length: np.ndarray, full_data: SasData
+    ) -> np.ndarray:
         """Calculate the q values needed to perform the Hankel transform
 
         Note: this is undefined for the case when spin_echo_lengths contains
@@ -71,7 +73,10 @@ class SesansModel(ModellingRequirements):
 
         """
         if len(spin_echo_length) == 1:
-            q_min, q_max = 0.01 * 2 * np.pi / spin_echo_length[-1], 10 * 2 * np.pi / spin_echo_length[0]
+            q_min, q_max = (
+                0.01 * 2 * np.pi / spin_echo_length[-1],
+                10 * 2 * np.pi / spin_echo_length[0],
+            )
         else:
             # TODO: Why does q_min depend on the number of correlation lengths?
             # TODO: Why does q_max depend on the correlation step size?
@@ -130,6 +135,7 @@ MINIMUM_ABSOLUTE_Q = 0.02  # relative to the minimum q in the data
 # it is better to use asymmetric bounds (2.5, 3.0)
 PINHOLE_N_SIGMA = (2.5, 3.0)
 
+
 class PinholeModel(ModellingRequirements):
     """Perform a pin hole smearing"""
 
@@ -144,21 +150,61 @@ class PinholeModel(ModellingRequirements):
         q_min = np.min(self.q - self.nsigma_low * self.q_width)
         q_max = np.max(self.q + self.nsigma_high * self.q_width)
 
-
         self.q_calc = linear_extrapolation(self.q, q_min, q_max)
 
         # Protect against models which are not defined for very low q.  Limit
         # the smallest q value evaluated (in absolute) to 0.02*min
-        cutoff = MINIMUM_ABSOLUTE_Q*np.min(self.q)
+        cutoff = MINIMUM_ABSOLUTE_Q * np.min(self.q)
         self.q_calc = self.q_calc[abs(self.q_calc) >= cutoff]
 
         # Build weight matrix from calculated q values
         self.weight_matrix = pinhole_resolution(
-            self.q_calc, self.q, np.maximum(self.q_width, MINIMUM_RESOLUTION),
-            nsigma=(self.nsigma_low, self.nsigma_high))
+            self.q_calc,
+            self.q,
+            np.maximum(self.q_width, MINIMUM_RESOLUTION),
+            nsigma=(self.nsigma_low, self.nsigma_high),
+        )
 
         return np.abs(self.q_calc)
 
+    def postprocess_iq(self, data: np.ndarray, full_data: SasData) -> np.ndarray:
+        """Perform smearing transform"""
+        return self.weight_matrix.T @ data
+
+
+class SlitModel(ModellingRequirements):
+    """Perform a slit smearing"""
+
+    def __init__(
+        self,
+        q_length: np.ndarray,
+        q_width: np.ndarray,
+        nsigma: (float, float) = PINHOLE_N_SIGMA,
+    ):
+        self.q_length = q_length
+        self.q_width = q_width
+        self.nsigma_low, self.nsigma_high = nsigma
+
+    def preprocess_q(self, q: np.ndarray, full_data: SasData) -> np.ndarray:
+        """Perform smearing transform"""
+        # FIXME: Actually do the smearing transform
+        self.q = q
+        q_min = np.min(self.q - self.nsigma_low * self.q_width)
+        q_max = np.max(self.q + self.nsigma_high * self.q_width)
+
+        self.q_calc = slit_extend_q(self.q, self.q_width, self.q_length)
+
+        # Protect against models which are not defined for very low q.  Limit
+        # the smallest q value evaluated (in absolute) to 0.02*min
+        cutoff = MINIMUM_ABSOLUTE_Q * np.min(self.q)
+        self.q_calc = self.q_calc[abs(self.q_calc) >= cutoff]
+
+        # Build weight matrix from calculated q values
+        self.weight_matrix = slit_resolution(
+            self.q_calc, self.q, self.q_length, self.q_width
+        )
+
+        return np.abs(self.q_calc)
 
     def postprocess_iq(self, data: np.ndarray, full_data: SasData) -> np.ndarray:
         """Perform smearing transform"""
@@ -171,13 +217,16 @@ class NullModel(ModellingRequirements):
     def compose(self, other: ModellingRequirements) -> ModellingRequirements:
         return other
 
-    def preprocess_q(self, data: Quantity[np.ndarray], _full_data: SasData) -> np.ndarray:
+    def preprocess_q(
+        self, data: Quantity[np.ndarray], _full_data: SasData
+    ) -> np.ndarray:
         """Do nothing"""
         return data
 
     def postprocess_iq(self, data: np.ndarray, _full_data: SasData) -> np.ndarray:
         """Do nothing"""
         return data
+
 
 def guess_requirements(data: SasData) -> ModellingRequirements:
     """Use names of axes and units to guess what kind of processing needs to be done"""
@@ -226,22 +275,24 @@ def linear_extrapolation(q, q_min, q_max):
     Note that extrapolated values may be negative.
     """
     q = np.sort(q)
-    if q_min + 2*MINIMUM_RESOLUTION < q[0]:
+    if q_min + 2 * MINIMUM_RESOLUTION < q[0]:
         delta = q[1] - q[0] if len(q) > 1 else 0
-        n_low = int(np.ceil((q[0]-q_min) / delta)) if delta > 0 else 15
-        q_low = np.linspace(q_min, q[0], n_low+1)[:-1]
+        n_low = int(np.ceil((q[0] - q_min) / delta)) if delta > 0 else 15
+        q_low = np.linspace(q_min, q[0], n_low + 1)[:-1]
     else:
         q_low = []
-    if q_max - 2*MINIMUM_RESOLUTION > q[-1]:
+    if q_max - 2 * MINIMUM_RESOLUTION > q[-1]:
         delta = q[-1] - q[-2] if len(q) > 1 else 0
-        n_high = int(np.ceil((q_max-q[-1]) / delta)) if delta > 0 else 15
-        q_high = np.linspace(q[-1], q_max, n_high+1)[1:]
+        n_high = int(np.ceil((q_max - q[-1]) / delta)) if delta > 0 else 15
+        q_high = np.linspace(q[-1], q_max, n_high + 1)[1:]
     else:
         q_high = []
     return np.concatenate([q_low, q, q_high])
 
 
-def pinhole_resolution(q_calc: np.ndarray, q: np.ndarray, q_width: np.ndarray, nsigma=PINHOLE_N_SIGMA) -> np.ndarray:
+def pinhole_resolution(
+    q_calc: np.ndarray, q: np.ndarray, q_width: np.ndarray, nsigma=PINHOLE_N_SIGMA
+) -> np.ndarray:
     r"""
     Compute the convolution matrix *W* for pinhole resolution 1-D data.
 
@@ -265,21 +316,22 @@ def pinhole_resolution(q_calc: np.ndarray, q: np.ndarray, q_width: np.ndarray, n
     # The current algorithm is a midpoint rectangle rule.  In the test case,
     # neither trapezoid nor Simpson's rule improved the accuracy.
     edges = bin_edges(q_calc)
-    #edges[edges < 0.0] = 0.0 # clip edges below zero
-    cdf = erf((edges[:, None] - q[None, :]) / (np.sqrt(2.0)*q_width)[None, :])
+    # edges[edges < 0.0] = 0.0 # clip edges below zero
+    cdf = erf((edges[:, None] - q[None, :]) / (np.sqrt(2.0) * q_width)[None, :])
     weights = cdf[1:] - cdf[:-1]
     # Limit q range to (-2.5,+3) sigma
     try:
         nsigma_low, nsigma_high = nsigma
     except TypeError:
         nsigma_low = nsigma_high = nsigma
-    qhigh = q + nsigma_high*q_width
-    qlow = q - nsigma_low*q_width  # linear limits
+    qhigh = q + nsigma_high * q_width
+    qlow = q - nsigma_low * q_width  # linear limits
     ##qlow = q*q/qhigh  # log limits
-    weights[q_calc[:, None] < qlow[None, :]] = 0.
-    weights[q_calc[:, None] > qhigh[None, :]] = 0.
+    weights[q_calc[:, None] < qlow[None, :]] = 0.0
+    weights[q_calc[:, None] > qhigh[None, :]] = 0.0
     weights /= np.sum(weights, axis=0)[None, :]
     return weights
+
 
 def bin_edges(x):
     """
@@ -291,9 +343,250 @@ def bin_edges(x):
     """
     if len(x) < 2 or (np.diff(x) < 0).any():
         raise ValueError("Expected bins to be an increasing set")
-    edges = np.hstack([
-        x[0]  - 0.5*(x[1]  - x[0]),  # first point minus half first interval
-        0.5*(x[1:] + x[:-1]),        # mid points of all central intervals
-        x[-1] + 0.5*(x[-1] - x[-2]), # last point plus half last interval
-        ])
+    edges = np.hstack(
+        [
+            x[0] - 0.5 * (x[1] - x[0]),  # first point minus half first interval
+            0.5 * (x[1:] + x[:-1]),  # mid points of all central intervals
+            x[-1] + 0.5 * (x[-1] - x[-2]),  # last point plus half last interval
+        ]
+    )
     return edges
+
+
+def slit_resolution(q_calc, q, width, length, n_length=30):
+    r"""
+    Build a weight matrix to compute *I_s(q)* from *I(q_calc)*, given
+    $q_\perp$ = *width* (in the high-resolution axis) and $q_\parallel$
+    = *length* (in the low resolution axis).  *n_length* is the number
+    of steps to use in the integration over $q_\parallel$ when both
+    $q_\perp$ and $q_\parallel$ are non-zero.
+
+    Each $q$ can have an independent width and length value even though
+    current instruments use the same slit setting for all measured points.
+
+    If slit length is large relative to width, use:
+
+    .. math::
+
+        I_s(q_i) = \frac{1}{\Delta q_\perp}
+            \int_0^{\Delta q_\perp}
+                I\left(\sqrt{q_i^2 + q_\perp^2}\right) \,dq_\perp
+
+    If slit width is large relative to length, use:
+
+    .. math::
+
+        I_s(q_i) = \frac{1}{2 \Delta q_\parallel}
+            \int_{-\Delta q_\parallel}^{\Delta q_\parallel}
+                I\left(|q_i + q_\parallel|\right) \,dq_\parallel
+
+    For a mixture of slit width and length use:
+
+    .. math::
+
+        I_s(q_i) = \frac{1}{2 \Delta q_\parallel \Delta q_\perp}
+            \int_{-\Delta q_\parallel}^{\Delta q_\parallel}
+            \int_0^{\Delta q_\perp}
+                I\left(\sqrt{(q_i + q_\parallel)^2 + q_\perp^2}\right)
+                \,dq_\perp dq_\parallel
+
+    **Definition**
+
+    We are using the mid-point integration rule to assign weights to each
+    element of a weight matrix $W$ so that
+
+    .. math::
+
+        I_s(q) = W\,I(q_\text{calc})
+
+    If *q_calc* is at the mid-point, we can infer the bin edges from the
+    pairwise averages of *q_calc*, adding the missing edges before
+    *q_calc[0]* and after *q_calc[-1]*.
+
+    For $q_\parallel = 0$, the smeared value can be computed numerically
+    using the $u$ substitution
+
+    .. math::
+
+        u_j = \sqrt{q_j^2 - q^2}
+
+    This gives
+
+    .. math::
+
+        I_s(q) \approx \sum_j I(u_j) \Delta u_j
+
+    where $I(u_j)$ is the value at the mid-point, and $\Delta u_j$ is the
+    difference between consecutive edges which have been first converted
+    to $u$.  Only $u_j \in [0, \Delta q_\perp]$ are used, which corresponds
+    to $q_j \in \left[q, \sqrt{q^2 + \Delta q_\perp}\right]$, so
+
+    .. math::
+
+        W_{ij} = \frac{1}{\Delta q_\perp} \Delta u_j
+               = \frac{1}{\Delta q_\perp} \left(
+                    \sqrt{q_{j+1}^2 - q_i^2} - \sqrt{q_j^2 - q_i^2} \right)
+            \ \text{if}\  q_j \in \left[q_i, \sqrt{q_i^2 + q_\perp^2}\right]
+
+    where $I_s(q_i)$ is the theory function being computed and $q_j$ are the
+    mid-points between the calculated values in *q_calc*.  We tweak the
+    edges of the initial and final intervals so that they lie on integration
+    limits.
+
+    (To be precise, the transformed midpoint $u(q_j)$ is not necessarily the
+    midpoint of the edges $u((q_{j-1}+q_j)/2)$ and $u((q_j + q_{j+1})/2)$,
+    but it is at least in the interval, so the approximation is going to be
+    a little better than the left or right Riemann sum, and should be
+    good enough for our purposes.)
+
+    For $q_\perp = 0$, the $u$ substitution is simpler:
+
+    .. math::
+
+        u_j = \left|q_j - q\right|
+
+    so
+
+    .. math::
+
+        W_{ij} = \frac{1}{2 \Delta q_\parallel} \Delta u_j
+            = \frac{1}{2 \Delta q_\parallel} (q_{j+1} - q_j)
+            \ \text{if}\ q_j \in
+                \left[q-\Delta q_\parallel, q+\Delta q_\parallel\right]
+
+    However, we need to support cases were $u_j < 0$, which means using
+    $2 (q_{j+1} - q_j)$ when $q_j \in \left[0, q_\parallel-q_i\right]$.
+    This is not an issue for $q_i > q_\parallel$.
+
+    For both $q_\perp > 0$ and $q_\parallel > 0$ we perform a 2 dimensional
+    integration with
+
+    .. math::
+
+        u_{jk} = \sqrt{q_j^2 - (q + (k\Delta q_\parallel/L))^2}
+            \ \text{for}\ k = -L \ldots L
+
+    for $L$ = *n_length*.  This gives
+
+    .. math::
+
+        W_{ij} = \frac{1}{2 \Delta q_\perp q_\parallel}
+            \sum_{k=-L}^L \Delta u_{jk}
+                \left(\frac{\Delta q_\parallel}{2 L + 1}\right)
+
+
+    """
+
+    # np.set_printoptions(precision=6, linewidth=10000)
+
+    # The current algorithm is a midpoint rectangle rule.
+    q_edges = bin_edges(q_calc)  # Note: requires q > 0
+    # q_edges[q_edges < 0.0] = 0.0 # clip edges below zero
+    weights = np.zeros((len(q), len(q_calc)), "d")
+
+    # print(q_calc)
+    for i, (qi, w, l) in enumerate(zip(q, width, length)):
+        if w == 0.0 and l == 0.0:
+            # Perfect resolution, so return the theory value directly.
+            # Note: assumes that q is a subset of q_calc.  If qi need not be
+            # in q_calc, then we can do a weighted interpolation by looking
+            # up qi in q_calc, then weighting the result by the relative
+            # distance to the neighbouring points.
+            weights[i, :] = q_calc == qi
+        elif l == 0:
+            weights[i, :] = _q_perp_weights(q_edges, qi, w)
+        elif w == 0:
+            in_x = 1.0 * ((q_calc >= qi - l) & (q_calc <= qi + l))
+            abs_x = 1.0 * (q_calc < abs(qi - l)) if qi < l else 0.0
+            # print(qi - l, qi + l)
+            # print(in_x + abs_x)
+            weights[i, :] = (in_x + abs_x) * np.diff(q_edges) / (2 * l)
+        else:
+            for k in range(-n_length, n_length + 1):
+                weights[i, :] += _q_perp_weights(q_edges, qi + k * l / n_length, w)
+            weights[i, :] /= 2 * n_length + 1
+
+    return weights.T
+
+
+def _q_perp_weights(q_edges, qi, w):
+    # Convert bin edges from q to u
+    u_limit = np.sqrt(qi**2 + w**2)
+    u_edges = q_edges**2 - qi**2
+    u_edges[q_edges < abs(qi)] = 0.0
+    u_edges[q_edges > u_limit] = u_limit**2 - qi**2
+    weights = np.diff(np.sqrt(u_edges)) / w
+    # print("i, qi",i,qi,qi+width)
+    # print(q_calc)
+    # print(weights)
+    return weights
+
+
+def slit_extend_q(q, width, length):
+    """
+    Given *q*, *width* and *length*, find a set of sampling points *q_calc* so
+    that each point I(q) has sufficient support from the underlying
+    function.
+    """
+    q_min, q_max = np.min(q - length), np.max(np.sqrt((q + length) ** 2 + width**2))
+
+    return geometric_extrapolation(q, q_min, q_max)
+
+
+def geometric_extrapolation(q, q_min, q_max, points_per_decade=None):
+    r"""
+    Extrapolate *q* to [*q_min*, *q_max*] using geometric steps, with the
+    average geometric step size in *q* as the step size.
+
+    if *q_min* is zero or less then *q[0]/10* is used instead.
+
+    *points_per_decade* sets the ratio between consecutive steps such
+    that there will be $n$ points used for every factor of 10 increase
+    in *q*.
+
+    If *points_per_decade* is not given, it will be estimated as follows.
+    Starting at $q_1$ and stepping geometrically by $\Delta q$ to $q_n$
+    in $n$ points gives a geometric average of:
+
+    .. math::
+
+         \log \Delta q = (\log q_n - \log q_1) / (n - 1)
+
+    From this we can compute the number of steps required to extend $q$
+    from $q_n$ to $q_\text{max}$ by $\Delta q$ as:
+
+    .. math::
+
+         n_\text{extend} = (\log q_\text{max} - \log q_n) / \log \Delta q
+
+    Substituting:
+
+    .. math::
+
+         n_\text{extend} = (n-1) (\log q_\text{max} - \log q_n)
+            / (\log q_n - \log q_1)
+    """
+    DEFAULT_POINTS_PER_DECADE = 10
+    q = np.sort(q)
+    data_min, data_max = q[0], q[-1]
+    if points_per_decade is None:
+        if data_max > data_min:
+            log_delta_q = (len(q) - 1) / (np.log(data_max) - np.log(data_min))
+        else:
+            log_delta_q = np.log(10.0) / DEFAULT_POINTS_PER_DECADE
+    else:
+        log_delta_q = np.log(10.0) / points_per_decade
+    if q_min < data_min:
+        if q_min <= 0:
+            q_min = data_min * MINIMUM_ABSOLUTE_Q
+        print(log_delta_q, q[0], q_min, data_min, MINIMUM_ABSOLUTE_Q)
+        n_low = int(np.ceil(log_delta_q * (np.log(q[0]) - np.log(q_min))))
+        q_low = np.logspace(np.log10(q_min), np.log10(q[0]), n_low + 1)[:-1]
+    else:
+        q_low = []
+    if q_max > data_max:
+        n_high = int(np.ceil(log_delta_q * (np.log(q_max) - np.log(data_max))))
+        q_high = np.logspace(np.log10(data_max), np.log10(q_max), n_high + 1)[1:]
+    else:
+        q_high = []
+    return np.concatenate([q_low, q, q_high])

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -49,8 +49,7 @@ def test_sesans_modelling():
         return f2
 
     # The Hankel transform of x is -r^-3
-    x = data._data_contents["SpinEchoLength"].in_units_of(units.angstroms)
-    q = req.preprocess_q(x, data)
+    q = req.preprocess_q(data._data_contents["SpinEchoLength"], data)
     result = req.postprocess_iq(sphere(q), data)
 
     y, yerr = data._data_contents["Depolarisation"].in_units_of_with_standard_error(unit_parser.parse("A-2 cm-1"))

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -7,8 +7,9 @@ import os
 import pytest
 
 
-from sasdata.model_requirements import guess_requirements, ComposeRequirements, SmearModel, SesansModel, NullModel
+from sasdata.model_requirements import guess_requirements, ComposeRequirements, PinholeModel, SesansModel, NullModel
 from sasdata.temp_sesans_reader import load_data
+from sasdata.quantities.quantity import Quantity
 from sasdata.quantities import units, unit_parser
 
 test_file_names = ["sphere2micron", "sphere_isis"]
@@ -58,20 +59,91 @@ def test_sesans_modelling():
     xi_squared = np.sum( ((y - result) / yerr)**2 ) / len(y)
     assert 1.0 < xi_squared < 1.5
 
+@pytest.mark.sesans
+def test_pinhole_zero():
+    data = Quantity(np.linspace(1e-4, 1e-1, 1000), units.per_angstrom)
+    req = PinholeModel()
+
+
+    def sphere(qr):
+        def sas_3j1x_x(x):
+            return (np.sin(x) - x * np.cos(x))/x**3
+        def form_volume(x):
+            return np.pi * 4.0 / 3.0 * x**3
+        radius = 10000 # 1 micron
+
+        bes = sas_3j1x_x(q*radius)
+        contrast = 5.4e-7 # Contrast is hard coded for best fit
+        form = contrast * form_volume(radius) * bes
+        f2 = 1.0e-4*form*form
+        return f2
+
+    # The Hankel transform of x is -r^-3
+    q = req.preprocess_q(data, None)
+    result = req.postprocess_iq(sphere(q), data)
+
+    for actual, expected in zip(result, sphere(q)):
+        assert actual == expected
+
+@pytest.mark.sesans
+def test_pinhole_smear():
+    smearing = [1000, 100, 20, 15, 10, 2, 1, 0.5, 0.2]
+    smears = [pinhole_smear(x) for x in smearing]
+    old = 0
+    for factor, smear in zip(smearing, smears):
+        print(factor, smear)
+        assert old < smear < 1.2
+        old = smear
+    assert pinhole_smear(3**6) > 1.2
+
+
+def pinhole_smear(smearing: float):
+    data = Quantity(np.linspace(1e-4, 1e-1, 1000), units.per_angstrom)
+    data = data.with_standard_error(data / smearing)
+    req = PinholeModel()
+
+
+    def sphere(qr):
+        def sas_3j1x_x(x):
+            return (np.sin(x) - x * np.cos(x))/x**3
+        def form_volume(x):
+            return np.pi * 4.0 / 3.0 * x**3
+        radius = 10000 # 1 micron
+
+        bes = sas_3j1x_x(qr)
+        contrast = 5.4e-7 # Contrast is hard coded for best fit
+        form = contrast * form_volume(radius) * bes
+        f2 = 1.0e-4*form*form
+        return f2
+
+    radius = 200
+
+    # The Hankel transform of x is -r^-3
+    inner_q = req.preprocess_q(data, None)
+    result = req.postprocess_iq(sphere(inner_q * radius), data)
+
+    # for actual, expected in zip(result, sphere(data.value * radius)):
+    #     assert actual != expected
+
+    y = sphere(data.value * radius)
+
+    xi_squared = np.sum( ((y - result)/result )**2 ) / len(y)
+    return xi_squared
+
 
 
 @pytest.mark.sesans
 def test_model_algebra():
     ses = SesansModel()
-    sme = SmearModel()
+    pin = PinholeModel()
     null = NullModel()
 
     # Ignore slit smearing if we perform a sesans transform afterwards
-    assert type(sme + ses) is SesansModel
+    assert type(pin + ses) is SesansModel
     # However, it is possible for the spin echo lengths to have some
     # smearing between them.
-    assert type(ses + sme) is ComposeRequirements
+    assert type(ses + pin) is ComposeRequirements
     assert type(null + ses) is SesansModel
-    assert type(null + sme) is SmearModel
+    assert type(null + pin) is PinholeModel
     assert type(ses + null) is SesansModel
-    assert type(sme + null) is SmearModel
+    assert type(pin + null) is PinholeModel

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -110,14 +110,18 @@ def smear(req: ModellingRequirements, data: np.ndarray, y=None, full_data=None, 
 def test_model_algebra():
     ses = SesansModel()
     pin = PinholeModel(np.linspace(1e-3, 1, 1000))
+    slit = SlitModel(np.linspace(1e-3, 1, 1000), np.linspace(1e-3, 1, 1000))
     null = NullModel()
 
     # Ignore slit smearing if we perform a sesans transform afterwards
     assert type(pin + ses) is SesansModel
+    assert type(slit + ses) is SesansModel
     # However, it is possible for the spin echo lengths to have some
     # smearing between them.
     assert type(ses + pin) is ComposeRequirements
     assert type(null + ses) is SesansModel
+    assert type(null + slit) is SlitModel
     assert type(null + pin) is PinholeModel
     assert type(ses + null) is SesansModel
     assert type(pin + null) is PinholeModel
+    assert type(slit + null) is SlitModel

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -65,7 +65,7 @@ def test_pinhole_zero():
 
 @pytest.mark.sesans
 def test_pinhole_smear():
-    smearing = [1e-3, 1e-2, 2e-1, 1.5e-1, 0.1, 0.25, 0.3, 0.5, 1, 2, 5]
+    smearing = [10**x for x in range(-3, 3)]
     smears = [pinhole_smear(x) for x in smearing]
     old = 0
     for factor, smear in zip(smearing, smears):
@@ -77,7 +77,7 @@ def test_pinhole_smear():
 
 def pinhole_smear(smearing: float):
     data = Quantity(np.linspace(1e-5, 1e-3, 1000), units.per_angstrom)
-    data = data.with_standard_error(data * smearing)
+    data = data.with_standard_error(Quantity(np.diff(data.value, prepend=0) * smearing, units.per_angstrom))
     req = PinholeModel()
     return smear(req, data)
 

--- a/test/sasdataloader/utest_new_sesans.py
+++ b/test/sasdataloader/utest_new_sesans.py
@@ -52,7 +52,7 @@ def test_pinhole_zero():
 
 @pytest.mark.sesans
 def test_pinhole_smear():
-    smearing = [10**x for x in range(-3, 3)]
+    smearing = [3**x for x in range(-1, 6)]
     smears = [pinhole_smear(x) for x in smearing]
     old = 0
     for factor, smear in zip(smearing, smears):


### PR DESCRIPTION
This PR adds full support for slit and pinhole smearing models to the new refactoring.  Much of the calculation has been ported from sasmodels, though I have taken some effort to vectorise the calculations.  The gave about an 80% speedup on the slit smearing.

I've also added a testing framework for the smearing.  Instead of comparing against hard coded values (like the old tests), these tests confirm that

- An infinitely small slit or pinhole returns the exact same value as the original signal
- That a small slit or pinhole returns a signal close to the original signal (Χ² is near zero)
- That the Χ² increases as the slit or pinhole increases in size
- That Χ² doesn't grow too large, even for large apertures.