### PR TITLE
Adds Pyupgrade (UP) ruleset and rules SIM118 & SIM300 to ruff linter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,9 @@ line-length = 120
 [tool.ruff.lint]
 # The ruff rules are available at: https://docs.astral.sh/ruff/rules/
 select = ["E",       # pycodestyle errors
-          "F"]       # pyflakes
+          "F",       # pyflakes
+          "UP"]      # pyupgrade
 
-ignore = ["E501"]    # line too long (leave to formatter)
+ignore = ["E501",    # line too long (leave to formatter)
+          "UP008",   # Use `super()` instead of `super(__class__, self)`
+          "UP031"]   # Use format specifiers instead of percent format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,10 @@ line-length = 120
 # The ruff rules are available at: https://docs.astral.sh/ruff/rules/
 select = ["E",       # pycodestyle errors
           "F",       # pyflakes
-          "UP"]      # pyupgrade
+          "UP",      # pyupgrade
+          "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
+          "SIM300"]  # Yoda condition detected
+
 
 ignore = ["E501",    # line too long (leave to formatter)
           "UP008",   # Use `super()` instead of `super(__class__, self)`

--- a/sasdata/ascii_reader_metadata.py
+++ b/sasdata/ascii_reader_metadata.py
@@ -36,7 +36,7 @@ class AsciiMetadataCategory[T]:
     values: dict[str, T] = field(default_factory=dict)
 
 def default_categories() -> dict[str, AsciiMetadataCategory[str | int]]:
-    return {key: AsciiMetadataCategory() for key in initial_metadata.keys()}
+    return {key: AsciiMetadataCategory() for key in initial_metadata}
 
 @dataclass
 class AsciiReaderMetadata:

--- a/sasdata/data.py
+++ b/sasdata/data.py
@@ -16,7 +16,7 @@ class SasData:
 
         self.name = name
         # validate data contents
-        if not all([key in dataset_type.optional or key in dataset_type.required for key in data_contents.keys()]):
+        if not all([key in dataset_type.optional or key in dataset_type.required for key in data_contents]):
             raise ValueError("Columns don't match the dataset type")
         self._data_contents = data_contents
         self._verbose = verbose

--- a/sasdata/data_util/loader_exceptions.py
+++ b/sasdata/data_util/loader_exceptions.py
@@ -2,7 +2,6 @@
 Exceptions specific to loading data.
 """
 
-from typing import Optional
 
 
 class NoKnownLoaderException(Exception):
@@ -11,7 +10,7 @@ class NoKnownLoaderException(Exception):
     extension of the loaded file. This exception should only be thrown by
     loader.py.
     """
-    def __init__(self, e: Optional[str] = None):
+    def __init__(self, e: str | None = None):
         self.message = e
 
 
@@ -20,7 +19,7 @@ class DefaultReaderException(Exception):
     Exception for files with no associated reader. This should be thrown by
     default readers only to tell Loader to try the next reader.
     """
-    def __init__(self, e: Optional[str] = None):
+    def __init__(self, e: str | None = None):
         self.message = e
 
 
@@ -29,7 +28,7 @@ class FileContentsException(Exception):
     Exception for files with an associated reader, but with no loadable data.
     This is useful for catching loader or file format issues.
     """
-    def __init__(self, e: Optional[str] = None):
+    def __init__(self, e: str | None = None):
         self.message = e
 
 
@@ -39,5 +38,5 @@ class DataReaderException(Exception):
     along the way.
     Any exceptions of this type should be put into the datainfo.errors
     """
-    def __init__(self, e: Optional[str] = None):
+    def __init__(self, e: str | None = None):
         self.message = e

--- a/sasdata/data_util/manipulations.py
+++ b/sasdata/data_util/manipulations.py
@@ -21,7 +21,6 @@ PYTHONPATH=../src/ python2  -m sasdataloader.test.utest_averaging DataInfoTests.
 # TODO: copy the meta data from the 2D object to the resulting 1D object
 import math
 import numpy as np
-from typing import Optional, Union
 
 from sasdata.dataloader.data_info import Data1D, Data2D
 
@@ -41,7 +40,7 @@ def position_and_wavelength_to_q(dx: float, dy: float, detector_distance: float,
     return (4.0 * math.pi / wavelength) * math.sin(theta)
 
 
-def get_q_compo(dx: float, dy: float, detector_distance: float, wavelength: float, compo: Optional[str] = None) -> float:
+def get_q_compo(dx: float, dy: float, detector_distance: float, wavelength: float, compo: str | None = None) -> float:
     """
     This reduces tiny error at very large q.
     Implementation of this func is not started yet.<--ToDo
@@ -102,7 +101,7 @@ def get_pixel_fraction_square(x: float, x_min: float, x_max: float) -> float:
         return 1.0
 
 
-def get_intercept(q: float, q_0: float, q_1: float) -> Union[float, None]:
+def get_intercept(q: float, q_0: float, q_1: float) -> float | None:
     """
     Returns the fraction of the side at which the
     q-value intercept the pixel, None otherwise.
@@ -235,7 +234,7 @@ def get_dq_data(data2d: Data2D) -> np.array:
 ################################################################################
 
 
-def reader2D_converter(data2d: Optional[Data2D] = None) -> Data2D:
+def reader2D_converter(data2d: Data2D | None = None) -> Data2D:
     """
     convert old 2d format opened by IhorReader or danse_reader
     to new Data2D format

--- a/sasdata/data_util/nxsunit.py
+++ b/sasdata/data_util/nxsunit.py
@@ -51,8 +51,8 @@ from collections.abc import Sequence
 __all__ = ['Converter', 'standardize_units']
 T = TypeVar('T')
 ConversionType = float | tuple[float, float]
-DIMENSIONS = {}  # type: dict[str, dict[str, ConversionType]]
-AMBIGUITIES = {}  # type: dict[str, str]
+DIMENSIONS: dict[str, dict[str, ConversionType]] = {}
+AMBIGUITIES: dict[str, str] = {}
 PREFIX = dict(peta=1e15, tera=1e12, giga=1e9, mega=1e6, kilo=1e3, deci=1e-1, centi=1e-2, milli=1e-3, mili=1e-3,
               micro=1e-6, nano=1e-9, pico=1e-12, femto=1e-15)
 SHORT_PREFIX = dict(P=1e15, T=1e12, G=1e9, M=1e6, k=1e3, d=1e-1, c=1e-2, m=1e-3, u=1e-6, n=1e-9, p=1e-12, f=1e-15)
@@ -258,7 +258,7 @@ def _build_all_units():
     # APS files may be using 'a.u.' for 'arbitrary units'.  Other
     # facilities are leaving the units blank, using ??? or not even
     # writing the units attributes.
-    unknown = {}  # type: dict[str, ConversionType]
+    unknown: dict[str, ConversionType] = {}
     unknown.update(
         {'None': 1, '???': 1, '': 1, 'A.U.': 1,  'a.u.': 1, 'arbitrary': 1, 'arbitrary units': 1,
          'Counts': 1, 'counts': 1, 'Cts': 1, 'cts': 1, 'unitless': 1, 'unknown': 1, 'Unknown': 1, 'Unk': 1}
@@ -356,15 +356,15 @@ class Converter:
     value name.
     """
     #: Name of the source units (km, Ang, us, ...)
-    _units = None  # type: list[str]
+    _units: list[str] = None
     #: Type of the source units (distance, time, frequency, ...)
-    dimension = None  # type: list[str]
+    dimension: list[str] = None
     #: Scale converter, mapping unit name to scale factor or (scale, offset)
     #: for temperature units.
-    scalemap = None  # type: list[dict[str, ConversionType]]
+    scalemap: list[dict[str, ConversionType]] = None
     #: Scale base for the source units
-    scalebase = None  # type: float
-    scaleoffset = None  # type: float
+    scalebase: float = None
+    scaleoffset: float = None
 
     @property
     def units(self) -> str:
@@ -375,7 +375,7 @@ class Converter:
         self._units = standardize_units(unit)
 
     def __init__(self, units: str | None = None, dimension: list[str] | None = None):
-        self.units = units if units is not None else 'a.u.'  # type: str
+        self.units: str = units if units is not None else 'a.u.'
 
         # Lookup dimension if not given
         if dimension:

--- a/sasdata/data_util/nxsunit.py
+++ b/sasdata/data_util/nxsunit.py
@@ -45,13 +45,14 @@ inferring the dimension from an example unit.
 
 import math
 import re
-from typing import Dict, Union, TypeVar, Tuple, Sequence, Optional, List
+from typing import TypeVar
+from collections.abc import Sequence
 
 __all__ = ['Converter', 'standardize_units']
 T = TypeVar('T')
-ConversionType = Union[float, Tuple[float, float]]
-DIMENSIONS = {}  # type: Dict[str, Dict[str, ConversionType]]
-AMBIGUITIES = {}  # type: Dict[str, str]
+ConversionType = float | tuple[float, float]
+DIMENSIONS = {}  # type: dict[str, dict[str, ConversionType]]
+AMBIGUITIES = {}  # type: dict[str, str]
 PREFIX = dict(peta=1e15, tera=1e12, giga=1e9, mega=1e6, kilo=1e3, deci=1e-1, centi=1e-2, milli=1e-3, mili=1e-3,
               micro=1e-6, nano=1e-9, pico=1e-12, femto=1e-15)
 SHORT_PREFIX = dict(P=1e15, T=1e12, G=1e9, M=1e6, k=1e3, d=1e-1, c=1e-2, m=1e-3, u=1e-6, n=1e-9, p=1e-12, f=1e-15)
@@ -60,7 +61,7 @@ SHORT_PREFIX = dict(P=1e15, T=1e12, G=1e9, M=1e6, k=1e3, d=1e-1, c=1e-2, m=1e-3,
 # Limited form of units for returning objects of a specific type.
 # Maybe want to do full units handling with e.g., pyre's
 # unit class. For now lets keep it simple.  Note that
-def _build_metric_units(unit: str, abbr: str) -> Dict[str, float]:
+def _build_metric_units(unit: str, abbr: str) -> dict[str, float]:
     """
     Construct standard SI names for the given unit.
     Builds e.g.,
@@ -89,7 +90,7 @@ def _build_metric_units(unit: str, abbr: str) -> Dict[str, float]:
     return units
 
 
-def _build_plural_units(**kw: Dict[str, ConversionType]) -> Dict[str, ConversionType]:
+def _build_plural_units(**kw: dict[str, ConversionType]) -> dict[str, ConversionType]:
     """
     Construct names for the given units.  Builds singular and plural form.
     """
@@ -99,7 +100,7 @@ def _build_plural_units(**kw: Dict[str, ConversionType]) -> Dict[str, Conversion
     return units
 
 
-def _build_degree_units(name: str, symbol: str, conversion: ConversionType) -> Dict[str, ConversionType]:
+def _build_degree_units(name: str, symbol: str, conversion: ConversionType) -> dict[str, ConversionType]:
     """
     Builds variations on the temperature unit name, including the degree
     symbol or the word degree.
@@ -118,7 +119,7 @@ def _build_degree_units(name: str, symbol: str, conversion: ConversionType) -> D
 
 
 def _build_inv_n_units(names: Sequence[str], conversion: ConversionType,
-                       n: int = 2) -> Dict[str, ConversionType]:
+                       n: int = 2) -> dict[str, ConversionType]:
     """
     Builds variations on inverse x to the nth power units, including 1/x^n, invx^n, x^-n and x^{-n}.
     """
@@ -132,7 +133,7 @@ def _build_inv_n_units(names: Sequence[str], conversion: ConversionType,
     return units
 
 
-def _build_inv_n_metric_units(unit: str, abbr: str, n: int = 2) -> Dict[str, ConversionType]:
+def _build_inv_n_metric_units(unit: str, abbr: str, n: int = 2) -> dict[str, ConversionType]:
     """
     Using the return from _build_metric_units, build inverse to the nth power variations on all units
     (1/x^n, invx^n, x^{-n} and x^-n)
@@ -257,7 +258,7 @@ def _build_all_units():
     # APS files may be using 'a.u.' for 'arbitrary units'.  Other
     # facilities are leaving the units blank, using ??? or not even
     # writing the units attributes.
-    unknown = {}  # type: Dict[str, ConversionType]
+    unknown = {}  # type: dict[str, ConversionType]
     unknown.update(
         {'None': 1, '???': 1, '': 1, 'A.U.': 1,  'a.u.': 1, 'arbitrary': 1, 'arbitrary units': 1,
          'Counts': 1, 'counts': 1, 'Cts': 1, 'cts': 1, 'unitless': 1, 'unknown': 1, 'Unknown': 1, 'Unk': 1}
@@ -265,7 +266,7 @@ def _build_all_units():
     DIMENSIONS['dimensionless'] = unknown
 
 
-def standardize_units(unit: Union[str, None]) -> List[str]:
+def standardize_units(unit: str | None) -> list[str]:
     """
     Convert supplied units to a standard format for maintainability
     :param unit: Raw unit as supplied
@@ -301,7 +302,7 @@ def standardize_units(unit: Union[str, None]) -> List[str]:
     return _format_unit_structure(unit)
 
 
-def _format_unit_structure(unit: Optional[str] = None) -> List[str]:
+def _format_unit_structure(unit: str | None = None) -> list[str]:
     """
     Format units a common way
     :param unit: Unit string to be formatted
@@ -355,12 +356,12 @@ class Converter:
     value name.
     """
     #: Name of the source units (km, Ang, us, ...)
-    _units = None  # type: List[str]
+    _units = None  # type: list[str]
     #: Type of the source units (distance, time, frequency, ...)
-    dimension = None  # type: List[str]
+    dimension = None  # type: list[str]
     #: Scale converter, mapping unit name to scale factor or (scale, offset)
     #: for temperature units.
-    scalemap = None  # type: List[Dict[str, ConversionType]]
+    scalemap = None  # type: list[dict[str, ConversionType]]
     #: Scale base for the source units
     scalebase = None  # type: float
     scaleoffset = None  # type: float
@@ -373,7 +374,7 @@ class Converter:
     def units(self, unit: str):
         self._units = standardize_units(unit)
 
-    def __init__(self, units: Optional[str] = None, dimension: Optional[List[str]] = None):
+    def __init__(self, units: str | None = None, dimension: list[str] | None = None):
         self.units = units if units is not None else 'a.u.'  # type: str
 
         # Lookup dimension if not given
@@ -398,20 +399,20 @@ class Converter:
         self.scalebase = base[0]
         self.scaleoffset = base[1]
 
-    def scale(self, units: str = "", value: T = None) -> Union[List[float], T]:
+    def scale(self, units: str = "", value: T = None) -> list[float] | T:
         """Scale the given value using the units string supplied"""
         units = standardize_units(units) if units is not None else ['']
         base = self._get_scale_for_units(units)
         value = self._scale_with_offset(value, base)
         return value
 
-    def _scale_with_offset(self, value: float, scale_base: Tuple[float, float]) -> float:
+    def _scale_with_offset(self, value: float, scale_base: tuple[float, float]) -> float:
         """Scale the given value and add the offset using the units string supplied"""
         inscale, inoffset = self.scalebase, self.scaleoffset
         outscale, outoffset = scale_base
         return (value + outoffset) * inscale / outscale - inoffset
 
-    def _get_scale_for_units(self, units: List[str]):
+    def _get_scale_for_units(self, units: list[str]):
         """Protected method to get scale factor and scale offset as a combined value"""
         base = (1.0, 0.0)
         for scalemap, unit in zip(self.scalemap, units):
@@ -423,7 +424,7 @@ class Converter:
             base = (base[0] * unit_scale[0], base[1] + unit_scale[1])
         return base
 
-    def get_compatible_units(self) -> List[str]:
+    def get_compatible_units(self) -> list[str]:
         """Return a list of compatible units for the current Convertor object"""
         unique_units = []
         conv_list = []
@@ -436,7 +437,7 @@ class Converter:
             unique_units = [x for _, x in sorted(zip(conv_list, unique_units))]
         return unique_units
 
-    def __call__(self, value: T, units: Optional[str] = "") -> Union[List[float], T]:
+    def __call__(self, value: T, units: str | None = "") -> list[float] | T:
         # Note: calculating a*1 rather than simply returning a would produce
         # an unnecessary copy of the array, which in the case of the raw
         # counts array would be bad.  Sometimes copying and other times

--- a/sasdata/data_util/registry.py
+++ b/sasdata/data_util/registry.py
@@ -7,7 +7,7 @@ and registers the built-in file extensions.
 import os
 from urllib.request import urlopen
 from io import BytesIO
-from typing import Optional, List, Union, TYPE_CHECKING
+from typing import Union, TYPE_CHECKING
 from collections import defaultdict
 from pathlib import Path
 
@@ -25,7 +25,7 @@ DEPRECATION_MESSAGE = ("\rThe extension, {}, of the file, {}, suggests the data 
                        "was made, but, should it be successful, SasView cannot guarantee the accuracy of the data.")
 
 
-def create_empty_data_with_errors(path: Union[str, Path], errors: List[Exception]):
+def create_empty_data_with_errors(path: str | Path, errors: list[Exception]):
     """Create a Data1D instance that only holds errors and a filepath. This allows all file paths to return a common
     data type, regardless if the data loading was successful or a failure."""
     from sasdata.dataloader.data_info import Data1D
@@ -121,13 +121,13 @@ class ExtensionRegistry:
     def __setitem__(self, ext: str, loader):
         self.readers[ext].insert(0, loader)
 
-    def __getitem__(self, ext: str) -> List:
+    def __getitem__(self, ext: str) -> list:
         return self.readers[ext]
 
     def __contains__(self, ext: str) -> bool:
         return ext in self.readers
 
-    def formats(self) -> List[str]:
+    def formats(self) -> list[str]:
         """
         Return a sorted list of the registered formats.
         """
@@ -135,7 +135,7 @@ class ExtensionRegistry:
         names.sort()
         return names
 
-    def extensions(self) -> List[str]:
+    def extensions(self) -> list[str]:
         """
         Return a sorted list of registered extensions.
         """
@@ -143,7 +143,7 @@ class ExtensionRegistry:
         exts.sort()
         return exts
 
-    def lookup(self, path: str) -> List[callable]:
+    def lookup(self, path: str) -> list[callable]:
         """
         Return the loader associated with the file type of path.
 
@@ -162,7 +162,7 @@ class ExtensionRegistry:
         # Ensure the list of readers only includes unique values and the order is maintained
         return unique_preserve_order(readers)
 
-    def load(self, path: str, ext: Optional[str] = None) -> List[Union["Data1D", "Data2D"]]:
+    def load(self, path: str, ext: str | None = None) -> list[Union["Data1D", "Data2D"]]:
         """
         Call the loader for a single file.
 

--- a/sasdata/data_util/uncertainty.py
+++ b/sasdata/data_util/uncertainty.py
@@ -23,7 +23,7 @@ __all__ = ['Uncertainty']
 
 # TODO: rename to Measurement and add support for units?
 # TODO: C implementation of *,/,**?
-class Uncertainty(object):
+class Uncertainty:
     # Make standard deviation available
     def _getdx(self): return np.sqrt(self.variance)
     def _setdx(self,dx):

--- a/sasdata/data_util/util.py
+++ b/sasdata/data_util/util.py
@@ -1,7 +1,7 @@
-from typing import List, Any
+from typing import Any
 
 
-def unique_preserve_order(seq: List[Any]) -> List[Any]:
+def unique_preserve_order(seq: list[Any]) -> list[Any]:
     """ Remove duplicates from list preserving order
     Fastest according to benchmarks at https://www.peterbe.com/plog/uniqifiers-benchmark
     """

--- a/sasdata/dataloader/data_info.py
+++ b/sasdata/dataloader/data_info.py
@@ -28,7 +28,7 @@ import numpy as np
 from sasdata.data_util.uncertainty import Uncertainty
 
 
-class plottable_1D(object):
+class plottable_1D:
     """
     Data1D is a place holder for 1D plottables.
     """
@@ -84,7 +84,7 @@ class plottable_1D(object):
         self._yunit = unit
 
 
-class plottable_2D(object):
+class plottable_2D:
     """
     Data2D is a place holder for 2D plottables.
     """
@@ -164,7 +164,7 @@ class plottable_2D(object):
         self._zunit = unit
 
 
-class Vector(object):
+class Vector:
     """
     Vector class to hold multi-dimensional objects
     """
@@ -193,7 +193,7 @@ class Vector(object):
         return msg
 
 
-class Detector(object):
+class Detector:
     """
     Class to hold detector information
     """
@@ -248,7 +248,7 @@ class Detector(object):
         return _str
 
 
-class Aperture(object):
+class Aperture:
     # Name
     name = None
     # Type
@@ -266,7 +266,7 @@ class Aperture(object):
         self.size = Vector()
 
 
-class Collimation(object):
+class Collimation:
     """
     Class to hold collimation information
     """
@@ -293,7 +293,7 @@ class Collimation(object):
         return _str
 
 
-class Source(object):
+class Source:
     """
     Class to hold source information
     """
@@ -358,7 +358,7 @@ MUON = 'muon'
 ELECTRON = 'electron'
 
 
-class Sample(object):
+class Sample:
     """
     Class to hold the sample description
     """
@@ -411,7 +411,7 @@ class Sample(object):
         return _str
 
 
-class Process(object):
+class Process:
     """
     Class that holds information about the processes
     performed on the data.
@@ -452,7 +452,7 @@ class Process(object):
         return _str
 
 
-class TransmissionSpectrum(object):
+class TransmissionSpectrum:
     """
     Class that holds information about transmission spectrum
     for white beams and spallation sources.
@@ -476,19 +476,18 @@ class TransmissionSpectrum(object):
 
     def __str__(self):
         _str = "Transmission Spectrum:\n"
-        _str += "   Name:             \t{0}\n".format(self.name)
-        _str += "   Timestamp:        \t{0}\n".format(self.timestamp)
-        _str += "   Wavelength unit:  \t{0}\n".format(self.wavelength_unit)
-        _str += "   Transmission unit:\t{0}\n".format(self.transmission_unit)
-        _str += "   Trans. Dev. unit:  \t{0}\n".format(
-                                            self.transmission_deviation_unit)
+        _str += f"   Name:             \t{self.name}\n"
+        _str += f"   Timestamp:        \t{self.timestamp}\n"
+        _str += f"   Wavelength unit:  \t{self.wavelength_unit}\n"
+        _str += f"   Transmission unit:\t{self.transmission_unit}\n"
+        _str += f"   Trans. Dev. unit:  \t{self.transmission_deviation_unit}\n"
         length_list = [len(self.wavelength), len(self.transmission),
                        len(self.transmission_deviation)]
-        _str += "   Number of Pts:    \t{0}\n".format(max(length_list))
+        _str += f"   Number of Pts:    \t{max(length_list)}\n"
         return _str
 
 
-class DataInfo(object):
+class DataInfo:
     """
     Class to hold the data read from a file.
     It includes four blocks of data for the

--- a/sasdata/dataloader/filereader.py
+++ b/sasdata/dataloader/filereader.py
@@ -8,7 +8,6 @@ import codecs
 import logging
 from abc import abstractmethod
 from pathlib import Path
-from typing import List, Union, Optional
 
 import numpy as np
 from sasdata.data_util.loader_exceptions import NoKnownLoaderException
@@ -73,8 +72,8 @@ class FileReader:
         # Open file handle
         self.f_open = None
 
-    def read(self, filepath: Union[str, Path], file_handler: Optional[CustomFileOpen] = None,
-             f_pos: Optional[int] = 0) -> List[Union[Data1D, Data2D]]:
+    def read(self, filepath: str | Path, file_handler: CustomFileOpen | None = None,
+             f_pos: int | None = 0) -> list[Data1D | Data2D]:
         """
         Basic file reader
 
@@ -92,7 +91,7 @@ class FileReader:
                 return self._read(file_handler)
         return self._read(file_handler)
 
-    def _read(self, file_handler: CustomFileOpen) -> List[Union[Data1D, Data2D]]:
+    def _read(self, file_handler: CustomFileOpen) -> list[Data1D | Data2D]:
         """
         Private method to handle file loading
 
@@ -274,7 +273,7 @@ class FileReader:
         return array[ind]
 
     @staticmethod
-    def _remove_nans_in_data(data: Union[Data1D, Data2D]) -> Union[Data1D, Data2D]:
+    def _remove_nans_in_data(data: Data1D | Data2D) -> Data1D | Data2D:
         """
         Remove data points where nan is loaded
         :param data: 1D or 2D data object
@@ -301,7 +300,7 @@ class FileReader:
         return data
 
     @staticmethod
-    def set_default_1d_units(data: Union[Data1D, Data2D]) -> Union[Data1D, Data2D]:
+    def set_default_1d_units(data: Data1D | Data2D) -> Data1D | Data2D:
         """
         Set the x and y axes to the default 1D units
         :param data: 1D data set
@@ -312,7 +311,7 @@ class FileReader:
         return data
 
     @staticmethod
-    def set_default_2d_units(data: Union[Data1D, Data2D]) -> Union[Data1D, Data2D]:
+    def set_default_2d_units(data: Data1D | Data2D) -> Data1D | Data2D:
         """
         Set the x and y axes to the default 2D units
         :param data: 2D data set
@@ -494,7 +493,7 @@ class FileReader:
         self.current_dataset = plottable_1D(x, y, dx, dy)
 
     @staticmethod
-    def splitline(line: str) -> List[str]:
+    def splitline(line: str) -> list[str]:
         """
         Splits a line into pieces based on common delimiters
         :param line: A single line of text

--- a/sasdata/dataloader/loader.py
+++ b/sasdata/dataloader/loader.py
@@ -24,7 +24,6 @@ import time
 from zipfile import ZipFile
 from collections import defaultdict
 from types import ModuleType
-from typing import Optional, Union, List
 from itertools import zip_longest
 from pathlib import Path
 
@@ -59,10 +58,10 @@ class Registry(ExtensionRegistry):
         # Register default readers
         readers.read_associations(self)
 
-    def load(self, file_path_list: Union[List[Union[str, Path]], str, Path],
-             ext: Optional[Union[List[str], str]] = None,
-             debug: Optional[bool] = False,
-             use_defaults: Optional[bool] = True):
+    def load(self, file_path_list: list[str | Path] | str | Path,
+             ext: list[str] | str | None = None,
+             debug: bool | None = False,
+             use_defaults: bool | None = True):
         """
         Call the loader for the file type of path.
 
@@ -294,7 +293,7 @@ class Registry(ExtensionRegistry):
         # All done
         return writers
 
-    def save(self, path: str, data, format: Optional[str] = None):
+    def save(self, path: str, data, format: str | None = None):
         """
         Call the writer for the file type of path.
         Raises ValueError if no writer is available.
@@ -337,9 +336,9 @@ class Loader:
         """
         return self.__registry.associate_file_reader(ext, loader)
 
-    def load(self, file_path_list: Union[List[Union[str, Path]], str, Path],
-             format: Optional[Union[List[str], str]] = None
-             ) -> List[Union[Data1D, Data2D]]:
+    def load(self, file_path_list: list[str | Path] | str | Path,
+             format: list[str] | str | None = None
+             ) -> list[Data1D | Data2D]:
         """
         Load a file or series of files
         :param file_path_list: String representations of any number of file paths. This can either be a list or a string
@@ -377,7 +376,7 @@ class Loader:
         """
         return self.__registry.wildcards
 
-    def __call__(self, file_path_list: List[str]) -> List[Union[Data1D, Data2D]]:
+    def __call__(self, file_path_list: list[str]) -> list[Data1D | Data2D]:
         """Allow direct calls to the loader system for transient file loader systems.
         :param file_path_list: A list of string representations of file paths. Each item can either be a local file path
             or a URI.

--- a/sasdata/dataloader/readers/anton_paar_saxs_reader.py
+++ b/sasdata/dataloader/readers/anton_paar_saxs_reader.py
@@ -3,7 +3,6 @@
 """
 
 import numpy as np
-from typing import Optional
 from lxml.etree import Element
 
 from sasdata.dataloader.readers.xml_reader import XMLreader
@@ -127,7 +126,7 @@ class Reader(XMLreader):
         if not correctly_loaded:
             raise DataReaderException(error_message)
 
-    def _parse_child(self, dom: Element, parent: Optional[str] = ''):
+    def _parse_child(self, dom: Element, parent: str | None = ''):
         """
         Recursive method for stepping through the embedded XML
         :param dom: XML node with or without children

--- a/sasdata/dataloader/readers/ascii_reader.py
+++ b/sasdata/dataloader/readers/ascii_reader.py
@@ -13,7 +13,6 @@
 #############################################################################
 
 import logging
-from typing import Optional
 
 from sasdata.dataloader.filereader import FileReader
 from sasdata.dataloader.data_info import DataInfo, plottable_1D
@@ -133,23 +132,23 @@ class Reader(FileReader):
             self.set_all_to_none()
             if self.extension in self.ext:
                 msg = "ASCII Reader error: Fewer than five Q data points found "
-                msg += "in {}.".format(filename)
+                msg += f"in {filename}."
                 raise FileContentsException(msg)
             else:
-                msg = "ASCII Reader could not load the file {}".format(filename)
+                msg = f"ASCII Reader could not load the file {filename}"
                 raise DefaultReaderException(msg)
         # Sanity check
         if has_error_dy and not len(self.current_dataset.y) == \
                 len(self.current_dataset.dy):
             msg = "ASCII Reader error: Number of I and dI data points are"
-            msg += " different in {}.".format(filename)
+            msg += f" different in {filename}."
             # TODO: Add error to self.current_datainfo.errors instead?
             self.set_all_to_none()
             raise FileContentsException(msg)
         if has_error_dx and not len(self.current_dataset.x) == \
                 len(self.current_dataset.dx):
             msg = "ASCII Reader error: Number of Q and dQ data points are"
-            msg += " different in {}.".format(filename)
+            msg += f" different in {filename}."
             # TODO: Add error to self.current_datainfo.errors instead?
             self.set_all_to_none()
             raise FileContentsException(msg)
@@ -161,7 +160,7 @@ class Reader(FileReader):
         self.current_datainfo.meta_data['loader'] = self.type_name
         self.send_to_output()
 
-    def write(self, filename: str, dataset: plottable_1D, sep: Optional[str] = " "):
+    def write(self, filename: str, dataset: plottable_1D, sep: str | None = " "):
         """
         Output data in ascii or similar format, depending on the separator provided
 

--- a/sasdata/dataloader/readers/cansas_reader.py
+++ b/sasdata/dataloader/readers/cansas_reader.py
@@ -3,7 +3,6 @@ import os
 import datetime
 import inspect
 from inspect import FrameInfo
-from typing import Optional, Union
 
 import numpy as np
 from xml.dom.minidom import parseString
@@ -85,7 +84,7 @@ class Reader(XMLreader):
             # Raises FileContentsException
             is_valid_cansas = self.load_file_and_schema(xml_file, '')
         except FileContentsException:
-            msg = "CanSAS Reader could not load {}".format(xml_file)
+            msg = f"CanSAS Reader could not load {xml_file}"
             if self.extension not in self.ext:
                 # If the file has no associated loader
                 raise DefaultReaderException(msg)
@@ -119,7 +118,7 @@ class Reader(XMLreader):
             # Convert all other exceptions to FileContentsExceptions
             raise FileContentsException(str(e))
 
-    def load_file_and_schema(self, xml_file: str, schema_path: Optional[str] = "") -> bool:
+    def load_file_and_schema(self, xml_file: str, schema_path: str | None = "") -> bool:
         # Try and parse the XML file
         try:
             self.set_xml(xml_file)
@@ -134,7 +133,7 @@ class Reader(XMLreader):
             self.set_default_schema()
         return self.is_cansas(self.extension)
 
-    def is_cansas(self, ext: Optional[str] = "xml"):
+    def is_cansas(self, ext: str | None = "xml"):
         """
         Checks to see if the XML file is a CanSAS file
 
@@ -173,7 +172,7 @@ class Reader(XMLreader):
         )
         self.set_schema(schema_path)
 
-    def _parse_entry(self, dom: ElementTree, recurse: Optional[bool] = False) -> (Data1D, None):
+    def _parse_entry(self, dom: ElementTree, recurse: bool | None = False) -> (Data1D, None):
         if not self._is_call_local() and not recurse:
             self.reset_state()
         if not recurse:
@@ -738,7 +737,7 @@ class Reader(XMLreader):
                     err_msg = "CanSAS reader: unexpected "
                     err_msg += "\"{0}\" unit [{1}]; "
                     err_msg = err_msg.format(tagname, local_unit)
-                    err_msg += "expecting [{0}]".format(default_unit)
+                    err_msg += f"expecting [{default_unit}]"
                 value_unit = local_unit
             except Exception:
                 err_msg = "CanSAS reader: unknown error converting "
@@ -762,7 +761,7 @@ class Reader(XMLreader):
         self.current_dataset = plottable_1D(np.array(0), np.array(0))
 
     # Writing Methods
-    def write(self, filename: str, datainfo: Union[Data1D, Data2D]):
+    def write(self, filename: str, datainfo: Data1D | Data2D):
         """
         Write the content of a Data1D as a CanSAS XML file
 
@@ -779,7 +778,7 @@ class Reader(XMLreader):
                   pretty_print=True, xml_declaration=True)
         file_ref.close()
 
-    def _to_xml_doc(self, datainfo: Union[Data1D, Data2D]):
+    def _to_xml_doc(self, datainfo: Data1D | Data2D):
         """
         Create an XML document to contain the content of a Data1D
 
@@ -835,7 +834,7 @@ class Reader(XMLreader):
         doc, entry_node = self._check_origin(entry_node, doc)
         return doc, entry_node
 
-    def write_node(self, parent: ElementTree, name: str, value: Union[float, str], attr: Optional[dict] = None) -> bool:
+    def write_node(self, parent: ElementTree, name: str, value: float | str, attr: dict | None = None) -> bool:
         """
         :param doc: document DOM
         :param parent: parent node
@@ -880,7 +879,7 @@ class Reader(XMLreader):
                                         attrib=attrib, nsmap=nsmap)
         return main_node
 
-    def _write_run_names(self, datainfo: Union[Data1D, Data2D], entry_node: ElementTree):
+    def _write_run_names(self, datainfo: Data1D | Data2D, entry_node: ElementTree):
         """
         Writes the run names to the XML file
 
@@ -897,7 +896,7 @@ class Reader(XMLreader):
                 runname = {'name': datainfo.run_name[item]}
             self.write_node(entry_node, "Run", item, runname)
 
-    def _write_data(self, datainfo: Union[Data1D, Data2D], entry_node: ElementTree):
+    def _write_data(self, datainfo: Data1D | Data2D, entry_node: ElementTree):
         """
         Writes 1D I and Q data to the XML file
 
@@ -940,7 +939,7 @@ class Reader(XMLreader):
             self.write_node(entry_node, "zacceptance", datainfo.sample.zacceptance[0],
                              {'unit': datainfo.sample.zacceptance[1]})
 
-    def _write_data_2d(self, datainfo: Union[Data1D, Data2D], entry_node: ElementTree):
+    def _write_data_2d(self, datainfo: Data1D | Data2D, entry_node: ElementTree):
         """
         Writes 2D data to the XML file
 
@@ -982,7 +981,7 @@ class Reader(XMLreader):
             mask = ','.join("1" if v else "0" for v in datainfo.mask)
             self.write_node(point, "Mask", mask)
 
-    def _write_trans_spectrum(self, datainfo: Union[Data1D, Data2D], entry_node: ElementTree):
+    def _write_trans_spectrum(self, datainfo: Data1D | Data2D, entry_node: ElementTree):
         """
         Writes the transmission spectrum data to the XML file
 
@@ -1010,7 +1009,7 @@ class Reader(XMLreader):
                     point, "Tdev", spectrum.transmission_deviation[i],
                     {'unit': spectrum.transmission_deviation_unit})
 
-    def _write_sample_info(self, datainfo: Union[Data1D, Data2D], entry_node: ElementTree):
+    def _write_sample_info(self, datainfo: Data1D | Data2D, entry_node: ElementTree):
         """
         Writes the sample information to the XML file
 
@@ -1059,7 +1058,7 @@ class Reader(XMLreader):
         for item in datainfo.sample.details:
             self.write_node(sample, "details", item)
 
-    def _write_instrument(self, datainfo: Union[Data1D, Data2D], entry_node: ElementTree):
+    def _write_instrument(self, datainfo: Data1D | Data2D, entry_node: ElementTree):
         """
         Writes the instrumental information to the XML file
 
@@ -1071,7 +1070,7 @@ class Reader(XMLreader):
         self.write_node(instr, "name", datainfo.instrument)
         return instr
 
-    def _write_source(self, datainfo: Union[Data1D, Data2D], instr: ElementTree):
+    def _write_source(self, datainfo: Data1D | Data2D, instr: ElementTree):
         """
         Writes the source information to the XML file
 
@@ -1117,7 +1116,7 @@ class Reader(XMLreader):
                         datainfo.source.wavelength_spread,
                         {"unit": datainfo.source.wavelength_spread_unit})
 
-    def _write_collimation(self, datainfo: Union[Data1D, Data2D], instr: ElementTree):
+    def _write_collimation(self, datainfo: Data1D | Data2D, instr: ElementTree):
         """
         Writes the collimation information to the XML file
 
@@ -1162,7 +1161,7 @@ class Reader(XMLreader):
                 self.write_node(apert, "distance", aperture.distance,
                                 {"unit": aperture.distance_unit})
 
-    def _write_detectors(self, datainfo: Union[Data1D, Data2D], instr: ElementTree):
+    def _write_detectors(self, datainfo: Data1D | Data2D, instr: ElementTree):
         """
         Writes the detector information to the XML file
 
@@ -1228,7 +1227,7 @@ class Reader(XMLreader):
             self.write_node(det, "slit_length", item.slit_length,
                 {"unit": item.slit_length_unit})
 
-    def _write_process_notes(self, datainfo: Union[Data1D, Data2D], entry_node: ElementTree):
+    def _write_process_notes(self, datainfo: Data1D | Data2D, entry_node: ElementTree):
         """
         Writes the process notes to the XML file
 
@@ -1257,7 +1256,7 @@ class Reader(XMLreader):
             if len(item.notes) == 0:
                 self.write_node(node, "SASprocessnote", "")
 
-    def _write_notes(self, datainfo: Union[Data1D, Data2D], entry_node: ElementTree):
+    def _write_notes(self, datainfo: Data1D | Data2D, entry_node: ElementTree):
         """
         Writes the notes to the XML file and creates an empty note if none
         exist

--- a/sasdata/dataloader/readers/cansas_reader_HDF5.py
+++ b/sasdata/dataloader/readers/cansas_reader_HDF5.py
@@ -7,7 +7,7 @@ import h5py
 import numpy as np
 import re
 import traceback
-from typing import Any, Union, Optional
+from typing import Any
 
 from sasdata.dataloader.data_info import plottable_1D, plottable_2D, Data1D, Data2D, DataInfo, Process, Aperture,\
     Collimation, TransmissionSpectrum, Detector
@@ -93,13 +93,13 @@ class Reader(FileReader):
         self.errors = []
         self.logging = []
         self.q_names = []
-        self.mask_name = u''
-        self.i_name = u''
-        self.i_node = u''
-        self.i_uncertainties_name = u''
+        self.mask_name = ''
+        self.i_name = ''
+        self.i_node = ''
+        self.i_uncertainties_name = ''
         self.q_uncertainty_names = []
         self.q_resolution_names = []
-        self.parent_class = u''
+        self.parent_class = ''
         self.detector = Detector()
         self.collimation = Collimation()
         self.aperture = Aperture()
@@ -118,11 +118,11 @@ class Reader(FileReader):
         for key in data.keys():
             # Get all information for the current key
             value = data.get(key)
-            class_name = h5attr(value, u'canSAS_class')
+            class_name = h5attr(value, 'canSAS_class')
             if isinstance(class_name, (list, tuple, np.ndarray)):
                 class_name = class_name[0]
             if class_name is None:
-                class_name = h5attr(value, u'NX_class')
+                class_name = h5attr(value, 'NX_class')
             if class_name is not None:
                 class_prog = re.compile(class_name)
             else:
@@ -135,9 +135,9 @@ class Reader(FileReader):
                 parent_list.append(key)
                 # If a new sasentry, store the current data sets and create
                 # a fresh Data1D/2D object
-                if class_prog.match(u'SASentry'):
+                if class_prog.match('SASentry'):
                     self.add_data_set()
-                elif class_prog.match(u'SASdata'):
+                elif class_prog.match('SASdata'):
                     self._find_data_attributes(value)
                     self._initialize_new_data_set(value)
                 # Recursion step to access data within the group
@@ -166,7 +166,7 @@ class Reader(FileReader):
                     else:
                         data_point = decode(data_point)
                     # Top Level Meta Data
-                    if key == u'definition':
+                    if key == 'definition':
                         if isinstance(data_set, str):
                             self.current_datainfo.meta_data['reader'] = data_set
                             break
@@ -174,7 +174,7 @@ class Reader(FileReader):
                             self.current_datainfo.meta_data[
                                 'reader'] = data_point
                     # Run
-                    elif key == u'run':
+                    elif key == 'run':
                         try:
                             run_name = h5attr(value, 'name', default='name')
                             run_dict = {data_point: run_name}
@@ -187,47 +187,47 @@ class Reader(FileReader):
                         else:
                             self.current_datainfo.run.append(data_point)
                     # Title
-                    elif key == u'title':
+                    elif key == 'title':
                         if isinstance(data_set, str):
                             self.current_datainfo.title = data_set
                             break
                         else:
                             self.current_datainfo.title = data_point
                     # Note
-                    elif key == u'SASnote':
+                    elif key == 'SASnote':
                         self.current_datainfo.notes.append(data_set)
                         break
                     # Sample Information
-                    elif self.parent_class == u'SASsample':
+                    elif self.parent_class == 'SASsample':
                         self.process_sample(data_point, key)
                     # Instrumental Information
-                    elif (key == u'name'
-                          and self.parent_class == u'SASinstrument'):
+                    elif (key == 'name'
+                          and self.parent_class == 'SASinstrument'):
                         self.current_datainfo.instrument = data_point
                     # Detector
-                    elif self.parent_class == u'SASdetector':
+                    elif self.parent_class == 'SASdetector':
                         self.process_detector(data_point, key, unit)
                     # Collimation
-                    elif self.parent_class == u'SAScollimation':
+                    elif self.parent_class == 'SAScollimation':
                         self.process_collimation(data_point, key, unit)
                     # Aperture
-                    elif self.parent_class == u'SASaperture':
+                    elif self.parent_class == 'SASaperture':
                         self.process_aperture(data_point, key)
                     # Process Information
-                    elif self.parent_class == u'SASprocess': # CanSAS 2.0
+                    elif self.parent_class == 'SASprocess': # CanSAS 2.0
                         self.process_process(data_point, key)
                     # Source
-                    elif self.parent_class == u'SASsource':
+                    elif self.parent_class == 'SASsource':
                         self.process_source(data_point, key, unit)
                     # Everything else goes in meta_data
-                    elif self.parent_class == u'SASdata':
+                    elif self.parent_class == 'SASdata':
                         if isinstance(self.current_dataset, plottable_2D):
                             self.process_2d_data_object(data_set, key, unit)
                         else:
                             self.process_1d_data_object(data_set, key, unit)
 
                         break
-                    elif self.parent_class == u'SAStransmission_spectrum':
+                    elif self.parent_class == 'SAStransmission_spectrum':
                         self.process_trans_spectrum(data_set, key)
                         break
                     else:
@@ -281,7 +281,7 @@ class Reader(FileReader):
                 self.current_dataset.dx = data_set.flatten()
         elif key == self.mask_name:
             self.current_dataset.mask = data_set.flatten()
-        elif key == u'wavelength':
+        elif key == 'wavelength':
             self.current_datainfo.source.wavelength = data_set[0]
             self.current_datainfo.source.wavelength_unit = unit
 
@@ -324,15 +324,15 @@ class Reader(FileReader):
                 self.current_dataset.dqy_data = data_set.flatten()
         elif key == self.mask_name:
             self.current_dataset.mask = data_set.flatten()
-        elif key == u'Qy':
+        elif key == 'Qy':
             self.current_dataset.yaxis("Q_y", unit)
             self.current_dataset.qy_data = data_set.flatten()
-        elif key == u'Qydev':
+        elif key == 'Qydev':
             self.current_dataset.dqy_data = data_set.flatten()
-        elif key == u'Qx':
+        elif key == 'Qx':
             self.current_dataset.xaxis("Q_x", unit)
             self.current_dataset.qx_data = data_set.flatten()
-        elif key == u'Qxdev':
+        elif key == 'Qxdev':
             self.current_dataset.dqx_data = data_set.flatten()
 
     def process_trans_spectrum(self, data_set: np.array, key: str):
@@ -341,11 +341,11 @@ class Reader(FileReader):
         :param data_set: data from HDF5 file
         :param key: canSAS_class attribute
         """
-        if key == u'T':
+        if key == 'T':
             self.trans_spectrum.transmission = data_set.flatten()
-        elif key == u'Tdev':
+        elif key == 'Tdev':
             self.trans_spectrum.transmission_deviation = data_set.flatten()
-        elif key == u'lambda':
+        elif key == 'lambda':
             self.trans_spectrum.wavelength = data_set.flatten()
 
     def process_sample(self, data_point: Any, key: str):
@@ -354,29 +354,29 @@ class Reader(FileReader):
         :param data_point: Single point from an HDF5 data file
         :param key: class name data_point was taken from
         """
-        if key == u'Title':
+        if key == 'Title':
             self.current_datainfo.sample.name = data_point
-        elif key == u'name':
+        elif key == 'name':
             self.current_datainfo.sample.name = data_point
-        elif key == u'ID':
+        elif key == 'ID':
             self.current_datainfo.sample.name = data_point
-        elif key == u'thickness':
+        elif key == 'thickness':
             self.current_datainfo.sample.thickness = data_point
-        elif key == u'temperature':
+        elif key == 'temperature':
             self.current_datainfo.sample.temperature = data_point
-        elif key == u'transmission':
+        elif key == 'transmission':
             self.current_datainfo.sample.transmission = data_point
-        elif key == u'x_position':
+        elif key == 'x_position':
             self.current_datainfo.sample.position.x = data_point
-        elif key == u'y_position':
+        elif key == 'y_position':
             self.current_datainfo.sample.position.y = data_point
-        elif key == u'pitch':
+        elif key == 'pitch':
             self.current_datainfo.sample.orientation.x = data_point
-        elif key == u'yaw':
+        elif key == 'yaw':
             self.current_datainfo.sample.orientation.y = data_point
-        elif key == u'roll':
+        elif key == 'roll':
             self.current_datainfo.sample.orientation.z = data_point
-        elif key == u'details':
+        elif key == 'details':
             self.current_datainfo.sample.details.append(data_point)
 
     def process_detector(self, data_point: Any, key: str, unit: str):
@@ -386,39 +386,39 @@ class Reader(FileReader):
         :param key: class name data_point was taken from
         :param unit: unit attribute from data set
         """
-        if key == u'name':
+        if key == 'name':
             self.detector.name = data_point
-        elif key == u'SDD':
+        elif key == 'SDD':
             self.detector.distance = float(data_point)
             self.detector.distance_unit = unit
-        elif key == u'slit_length':
+        elif key == 'slit_length':
             self.detector.slit_length = float(data_point)
             self.detector.slit_length_unit = unit
-        elif key == u'x_position':
+        elif key == 'x_position':
             self.detector.offset.x = float(data_point)
             self.detector.offset_unit = unit
-        elif key == u'y_position':
+        elif key == 'y_position':
             self.detector.offset.y = float(data_point)
             self.detector.offset_unit = unit
-        elif key == u'pitch':
+        elif key == 'pitch':
             self.detector.orientation.x = float(data_point)
             self.detector.orientation_unit = unit
-        elif key == u'roll':
+        elif key == 'roll':
             self.detector.orientation.z = float(data_point)
             self.detector.orientation_unit = unit
-        elif key == u'yaw':
+        elif key == 'yaw':
             self.detector.orientation.y = float(data_point)
             self.detector.orientation_unit = unit
-        elif key == u'beam_center_x':
+        elif key == 'beam_center_x':
             self.detector.beam_center.x = float(data_point)
             self.detector.beam_center_unit = unit
-        elif key == u'beam_center_y':
+        elif key == 'beam_center_y':
             self.detector.beam_center.y = float(data_point)
             self.detector.beam_center_unit = unit
-        elif key == u'x_pixel_size':
+        elif key == 'x_pixel_size':
             self.detector.pixel_size.x = float(data_point)
             self.detector.pixel_size_unit = unit
-        elif key == u'y_pixel_size':
+        elif key == 'y_pixel_size':
             self.detector.pixel_size.y = float(data_point)
             self.detector.pixel_size_unit = unit
 
@@ -429,10 +429,10 @@ class Reader(FileReader):
         :param key: class name data_point was taken from
         :param unit: unit attribute from data set
         """
-        if key == u'distance':
+        if key == 'distance':
             self.collimation.length = data_point
             self.collimation.length_unit = unit
-        elif key == u'name':
+        elif key == 'name':
             self.collimation.name = data_point
 
     def process_aperture(self, data_point: Any, key: str):
@@ -441,11 +441,11 @@ class Reader(FileReader):
         :param data_point: Single point from an HDF5 data file
         :param key: class name data_point was taken from
         """
-        if key == u'shape':
+        if key == 'shape':
             self.aperture.shape = data_point
-        elif key == u'x_gap':
+        elif key == 'x_gap':
             self.aperture.size.x = data_point
-        elif key == u'y_gap':
+        elif key == 'y_gap':
             self.aperture.size.y = data_point
 
     def process_source(self, data_point: Any, key: str, unit: str):
@@ -455,31 +455,31 @@ class Reader(FileReader):
         :param key: class name data_point was taken from
         :param unit: unit attribute from data set
         """
-        if key == u'incident_wavelength':
+        if key == 'incident_wavelength':
             self.current_datainfo.source.wavelength = data_point
             self.current_datainfo.source.wavelength_unit = unit
-        elif key == u'wavelength_max':
+        elif key == 'wavelength_max':
             self.current_datainfo.source.wavelength_max = data_point
             self.current_datainfo.source.wavelength_max_unit = unit
-        elif key == u'wavelength_min':
+        elif key == 'wavelength_min':
             self.current_datainfo.source.wavelength_min = data_point
             self.current_datainfo.source.wavelength_min_unit = unit
-        elif key == u'incident_wavelength_spread':
+        elif key == 'incident_wavelength_spread':
             self.current_datainfo.source.wavelength_spread = data_point
             self.current_datainfo.source.wavelength_spread_unit = unit
-        elif key == u'beam_size_x':
+        elif key == 'beam_size_x':
             self.current_datainfo.source.beam_size.x = data_point
             self.current_datainfo.source.beam_size_unit = unit
-        elif key == u'beam_size_y':
+        elif key == 'beam_size_y':
             self.current_datainfo.source.beam_size.y = data_point
             self.current_datainfo.source.beam_size_unit = unit
-        elif key == u'beam_shape':
+        elif key == 'beam_shape':
             self.current_datainfo.source.beam_shape = data_point
-        elif key == u'radiation':
+        elif key == 'radiation':
             self.current_datainfo.source.radiation = data_point
-        elif key == u'type':
+        elif key == 'type':
             self.current_datainfo.source.type = data_point
-        elif key == u'probe':
+        elif key == 'probe':
             self.current_datainfo.source.probe = data_point
 
     def process_process(self, data_point: Any, key: str):
@@ -488,14 +488,14 @@ class Reader(FileReader):
         :param data_point: Single point from an HDF5 data file
         :param key: class name data_point was taken from
         """
-        term_match = re.compile(u'^term[0-9]+$')
-        if key == u'Title':  # CanSAS 2.0
+        term_match = re.compile('^term[0-9]+$')
+        if key == 'Title':  # CanSAS 2.0
             self.process.name = data_point
-        elif key == u'name':  # NXcanSAS
+        elif key == 'name':  # NXcanSAS
             self.process.name = data_point
-        elif key == u'description':
+        elif key == 'description':
             self.process.description = data_point
-        elif key == u'date':
+        elif key == 'date':
             self.process.date = data_point
         elif term_match.match(key):
             self.process.term.append(data_point)
@@ -511,22 +511,22 @@ class Reader(FileReader):
                        finished being processed
         """
 
-        if self.parent_class == u'SASprocess':
+        if self.parent_class == 'SASprocess':
             self.current_datainfo.process.append(self.process)
             self.process = Process()
-        elif self.parent_class == u'SASdetector':
+        elif self.parent_class == 'SASdetector':
             self.current_datainfo.detector.append(self.detector)
             self.detector = Detector()
-        elif self.parent_class == u'SAStransmission_spectrum':
+        elif self.parent_class == 'SAStransmission_spectrum':
             self.current_datainfo.trans_spectrum.append(self.trans_spectrum)
             self.trans_spectrum = TransmissionSpectrum()
-        elif self.parent_class == u'SAScollimation':
+        elif self.parent_class == 'SAScollimation':
             self.current_datainfo.collimation.append(self.collimation)
             self.collimation = Collimation()
-        elif self.parent_class == u'SASaperture':
+        elif self.parent_class == 'SASaperture':
             self.collimation.aperture.append(self.aperture)
             self.aperture = Aperture()
-        elif self.parent_class == u'SASdata':
+        elif self.parent_class == 'SASdata':
             if isinstance(self.current_dataset, plottable_2D):
                 self.data2d.append(self.current_dataset)
             elif isinstance(self.current_dataset, plottable_1D):
@@ -626,7 +626,7 @@ class Reader(FileReader):
         self.current_datainfo.filename = self.filepath.name
 
     @staticmethod
-    def as_list_or_array(data: Any) -> Union[list, np.ndarray]:
+    def as_list_or_array(data: Any) -> list | np.ndarray:
         """
         Return value as a list if not already a list or array.
         :param iterable:
@@ -643,10 +643,10 @@ class Reader(FileReader):
         :param value: SASdata/NXdata HDF5 Group
         """
         # Initialize values to base types
-        self.mask_name = u''
-        self.i_name = u''
-        self.i_node = u''
-        self.i_uncertainties_name = u''
+        self.mask_name = ''
+        self.i_name = ''
+        self.i_node = ''
+        self.i_uncertainties_name = ''
         self.q_names = []
         self.q_uncertainty_names = []
         self.q_resolution_names = []
@@ -700,7 +700,7 @@ class Reader(FileReader):
         return (i_vals is not None and len(i_vals.shape) != 1
                 and not self.multi_frame)
 
-    def _create_unique_key(self, dictionary: dict, name: str, numb: Optional[int] = 0) -> str:
+    def _create_unique_key(self, dictionary: dict, name: str, numb: int | None = 0) -> str:
         """
         Create a unique key value for any dictionary to prevent overwriting
         Recurses until a unique key value is found.
@@ -713,7 +713,7 @@ class Reader(FileReader):
         if dictionary.get(name) is not None:
             numb += 1
             name = name.split("_")[0]
-            name += "_{0}".format(numb)
+            name += f"_{numb}"
             name = self._create_unique_key(dictionary, name, numb)
         return name
 
@@ -724,12 +724,12 @@ class Reader(FileReader):
         :param value: attribute dictionary for a particular value set
         :return: unit for the value passed to the method
         """
-        unit = h5attr(value, u'units')
+        unit = h5attr(value, 'units')
         if unit is None:
-            unit = h5attr(value, u'unit')
+            unit = h5attr(value, 'unit')
         return unit
 
-    def write(self, filename: str, dataset: Union[Data1D, Data2D]):
+    def write(self, filename: str, dataset: Data1D | Data2D):
         """
         Export data in NXcanSAS format
 

--- a/sasdata/dataloader/readers/cansas_reader_HDF5.py
+++ b/sasdata/dataloader/readers/cansas_reader_HDF5.py
@@ -115,7 +115,7 @@ class Reader(FileReader):
         """
 
         # Loop through each element of the parent and process accordingly
-        for key in data.keys():
+        for key in data:
             # Get all information for the current key
             value = data.get(key)
             class_name = h5attr(value, 'canSAS_class')

--- a/sasdata/dataloader/readers/danse_reader.py
+++ b/sasdata/dataloader/readers/danse_reader.py
@@ -101,14 +101,14 @@ class Reader(FileReader):
                 elif toks[0] == "SIZE_Y":
                     size_y = int(toks[1])
             except ValueError:
-                error_message += "Unable to parse {}. Default value used.\n".format(toks[0])
+                error_message += f"Unable to parse {toks[0]}. Default value used.\n"
                 loaded_correctly = False
 
         # Read the data
         data = []
         error = []
         if not fversion >= 1.0:
-            msg = "danse_reader can't read this file {}".format(self.f_open.name)
+            msg = f"danse_reader can't read this file {self.f_open.name}"
             raise FileContentsException(msg)
 
         for line_num, data_str in enumerate(self.nextlines()):
@@ -119,17 +119,16 @@ class Reader(FileReader):
                 data.append(val)
                 error.append(err)
             except ValueError:
-                msg = "Unable to parse line {}: {}".format(line_num + data_start_line, data_str.strip())
+                msg = f"Unable to parse line {line_num + data_start_line}: {data_str.strip()}"
                 raise FileContentsException(msg)
 
         num_pts = size_x * size_y
         if len(data) < num_pts:
-            msg = "Not enough data points provided. Expected {} but got {}".format(
-                size_x * size_y, len(data))
+            msg = f"Not enough data points provided. Expected {size_x * size_y} but got {len(data)}"
             raise FileContentsException(msg)
         elif len(data) > num_pts:
-            error_message += ("Too many data points provided. Expected {0} but"
-                " got {1}. Only the first {0} will be used.\n").format(num_pts, len(data))
+            error_message += (f"Too many data points provided. Expected {num_pts} but"
+                f" got {len(data)}. Only the first {num_pts} will be used.\n")
             loaded_correctly = False
             data = data[:num_pts]
             error = error[:num_pts]

--- a/sasdata/dataloader/readers/xml_reader.py
+++ b/sasdata/dataloader/readers/xml_reader.py
@@ -249,7 +249,7 @@ class XMLreader(FileReader):
         if dictionary.get(name) is not None:
             numb += 1
             name = name.split("_")[0]
-            name += "_{0}".format(numb)
+            name += f"_{numb}"
             name = self._create_unique_key(dictionary, name, numb)
         return name
 

--- a/sasdata/file_converter/FileConverterUtilities.py
+++ b/sasdata/file_converter/FileConverterUtilities.py
@@ -21,7 +21,7 @@ def extract_ascii_data(filename):
         data = np.loadtxt(filename, dtype=str)
     except:
         # Check if file is a BSL or OTOKO header file
-        f = open(filename, 'r')
+        f = open(filename)
         f.readline()
         f.readline()
         bsl_metadata = f.readline().strip().split()
@@ -29,11 +29,11 @@ def extract_ascii_data(filename):
         if len(bsl_metadata) == 10:
             msg = ("Error parsing ASII data. {} looks like a BSL or OTOKO "
                    "header file.")
-            raise IOError(msg.format(os.path.split(filename)[-1]))
+            raise OSError(msg.format(os.path.split(filename)[-1]))
 
     if len(data.shape) != 1:
         msg = "Error reading {}: Only one column of data is allowed"
-        raise IOError(msg.format(filename.split('\\')[-1]))
+        raise OSError(msg.format(filename.split('\\')[-1]))
 
     is_float = True
     try:
@@ -49,7 +49,7 @@ def extract_ascii_data(filename):
         else:
             msg = ("Error reading {}: Lines must end with a digit, comma "
                    "or semi-colon").format(filename.split('\\')[-1])
-            raise IOError(msg)
+            raise OSError(msg)
 
     return np.array(data, dtype=np.float32)
 
@@ -68,7 +68,7 @@ def extract_otoko_data(qfile, ifile):
     if len(qdata) > 1:
         msg = ("Q-Axis file has multiple frames. Only 1 frame is "
                "allowed for the Q-Axis")
-        raise IOError(msg)
+        raise OSError(msg)
 
     qdata = qdata[0]
     return qdata, iqdata

--- a/sasdata/file_converter/ascii2d_loader.py
+++ b/sasdata/file_converter/ascii2d_loader.py
@@ -35,7 +35,7 @@ class ASCII2DLoader:
         :raises ValueError: Raises a ValueError if the file is incorrectly
             formatted
         """
-        with open(self.data_path, 'r') as file_handle:
+        with open(self.data_path) as file_handle:
             file_buffer = file_handle.read()
             all_lines = file_buffer.splitlines()
 
@@ -70,11 +70,10 @@ class ASCII2DLoader:
                 err_msg = "File incorrectly formatted.\n"
                 if str(e).find('broadcast') != -1:
                     err_msg += "Incorrect number of q data points provided. "
-                    err_msg += "Expected {}.".format(num_qs)
+                    err_msg += f"Expected {num_qs}."
                 elif str(e).find('invalid literal') != -1:
-                    err_msg += ("Expected integer on line {}. "
-                        "Instead got '{}'").format(current_line + 1,
-                            all_lines[current_line])
+                    err_msg += (f"Expected integer on line {current_line + 1}. "
+                        f"Instead got '{all_lines[current_line]}'")
                 else:
                     err_msg += str(e)
                 raise ValueError(err_msg)
@@ -89,16 +88,15 @@ class ASCII2DLoader:
                 height = int(dimensions[1])
             except ValueError:
                 err_msg = "File incorrectly formatted.\n"
-                err_msg += ("Expected line {} to be of the form: <num_qx> "
-                    "<num_qy> <scale>.").format(current_line + 1)
-                err_msg += " Instead got '{}'.".format(all_lines[current_line])
+                err_msg += (f"Expected line {current_line + 1} to be of the form: <num_qx> "
+                    "<num_qy> <scale>.")
+                err_msg += f" Instead got '{all_lines[current_line]}'."
                 raise ValueError(err_msg)
 
             if width > len(qx) or height > len(qy):
                 err_msg = "File incorrectly formatted.\n"
-                err_msg += ("Line {} says to use {}x{} points. "
-                    "Only {}x{} provided.").format(current_line + 1, width,
-                    height, len(qx), len(qy))
+                err_msg += (f"Line {current_line + 1} says to use {width}x{height} points. "
+                    f"Only {len(qx)}x{len(qy)} provided.")
                 raise ValueError(err_msg)
 
             # More qx and/or qy points can be provided than are actually used
@@ -116,8 +114,8 @@ class ASCII2DLoader:
             except:
                 err_msg = "File incorrectly formatted.\n"
                 iflag = all_lines[current_line].strip()[0]
-                err_msg += ("Expected iflag on line {} to be 1, 2 or 3. "
-                    "Instead got '{}'.").format(current_line+1, iflag)
+                err_msg += (f"Expected iflag on line {current_line+1} to be 1, 2 or 3. "
+                    f"Instead got '{iflag}'.")
                 raise ValueError(err_msg)
 
             current_line += 1
@@ -133,8 +131,8 @@ class ASCII2DLoader:
             except Exception as e:
                 err_msg = "File incorrectly formatted.\n"
                 if str(e).find("list index") != -1:
-                    err_msg += ("Incorrect number of data points. Expected {}"
-                        " intensity").format(width * height)
+                    err_msg += (f"Incorrect number of data points. Expected {width * height}"
+                        " intensity")
                     if iflag == 3:
                         err_msg += " and error"
                     err_msg += " points."

--- a/sasdata/file_converter/bsl_loader.py
+++ b/sasdata/file_converter/bsl_loader.py
@@ -28,14 +28,14 @@ class BSLLoader:
 
         sasdata_filename = filename.replace('000.', '001.')
         if sasdata_filename == filename:
-            err_msg = ("Invalid header filename {}.\nShould be of the format "
+            err_msg = (f"Invalid header filename {filename}.\nShould be of the format "
                        "Xnn000.XXX where X is any alphanumeric character and n is any"
-                       " digit.").format(filename)
+                       " digit.")
             raise BSLParsingError(err_msg)
 
         data_info = {}
 
-        with open(os.path.join(folder, filename), 'r') as header_file:
+        with open(os.path.join(folder, filename)) as header_file:
             data_info = self._parse_header(header_file, filename, sasdata_filename, folder)
 
         self.filename = data_info['filename']
@@ -61,7 +61,7 @@ class BSLLoader:
         data_filename = header_file.readline().strip()
 
         if len(metadata) != 10:
-            err_msg = "Invalid header file: {}".format(filename)
+            err_msg = f"Invalid header file: {filename}"
             raise BSLParsingError(err_msg)
 
         if data_filename != sasdata_filename:

--- a/sasdata/file_converter/nxcansas_writer.py
+++ b/sasdata/file_converter/nxcansas_writer.py
@@ -115,7 +115,7 @@ class NXcanSASWriter:
         sasentry.attrs['version'] = '1.1'
 
         for i, data_obj in enumerate(dataset):
-            data_entry = sasentry.create_group("sasdata{0:0=2d}".format(i+1))
+            data_entry = sasentry.create_group(f"sasdata{i+1:0=2d}")
             data_entry.attrs['canSAS_class'] = 'SASdata'
             if isinstance(data_obj, Data1D):
                 self._write_1d_data(data_obj, data_entry)
@@ -190,7 +190,7 @@ class NXcanSASWriter:
         if len(data_info.collimation) > 0:
             for i, coll_info in enumerate(data_info.collimation):
                 collimation_entry = instrument_entry.create_group(
-                    'sascollimation{0:0=2d}'.format(i + 1))
+                    f'sascollimation{i + 1:0=2d}')
                 collimation_entry.attrs['canSAS_class'] = 'SAScollimation'
                 if coll_info.length is not None:
                     _write_h5_float(collimation_entry, coll_info.length, 'SDD')
@@ -207,7 +207,7 @@ class NXcanSASWriter:
             i = 1
             for i, det_info in enumerate(data_info.detector):
                 detector_entry = instrument_entry.create_group(
-                    'sasdetector{0:0=2d}'.format(i + 1))
+                    f'sasdetector{i + 1:0=2d}')
                 detector_entry.attrs['canSAS_class'] = 'SASdetector'
                 if det_info.distance is not None:
                     _write_h5_float(detector_entry, det_info.distance, 'SDD')
@@ -243,8 +243,7 @@ class NXcanSASWriter:
 
         # Process meta data
         for i, process in enumerate(data_info.process):
-            process_entry = sasentry.create_group('sasprocess{0:0=2d}'.format(
-                i + 1))
+            process_entry = sasentry.create_group(f'sasprocess{i + 1:0=2d}')
             process_entry.attrs['canSAS_class'] = 'SASprocess'
             if process.name:
                 name = _h5_string(process.name)
@@ -259,19 +258,17 @@ class NXcanSASWriter:
                 # Don't save empty terms
                 if term:
                     h5_term = _h5_string(term)
-                    process_entry.create_dataset('term{0:0=2d}'.format(
-                        j + 1), data=h5_term)
+                    process_entry.create_dataset(f'term{j + 1:0=2d}', data=h5_term)
             for j, note in enumerate(process.notes):
                 # Don't save empty notes
                 if note:
                     h5_note = _h5_string(note)
-                    process_entry.create_dataset('note{0:0=2d}'.format(
-                        j + 1), data=h5_note)
+                    process_entry.create_dataset(f'note{j + 1:0=2d}', data=h5_note)
 
         # Transmission Spectrum
         for i, trans in enumerate(data_info.trans_spectrum):
             trans_entry = sasentry.create_group(
-                'sastransmission_spectrum{0:0=2d}'.format(i + 1))
+                f'sastransmission_spectrum{i + 1:0=2d}')
             trans_entry.attrs['canSAS_class'] = 'SAStransmission_spectrum'
             trans_entry.attrs['signal'] = 'T'
             trans_entry.attrs['T_axes'] = 'T'
@@ -297,7 +294,7 @@ class NXcanSASWriter:
             notes = [np.bytes_('')]
         if notes is not None:
             for i, note in enumerate(notes):
-                note_entry = sasentry.create_group('sasnote{0}'.format(i))
+                note_entry = sasentry.create_group(f'sasnote{i}')
                 note_entry.attrs['canSAS_class'] = 'SASnote'
                 note_entry.create_dataset('SASnote', data=note)
 

--- a/sasdata/file_converter/otoko_loader.py
+++ b/sasdata/file_converter/otoko_loader.py
@@ -70,7 +70,7 @@ class OTOKOLoader:
         total_frames = 0
         header_dir = os.path.dirname(os.path.abspath(header_path))
 
-        with open(header_path, "r") as header_file:
+        with open(header_path) as header_file:
             lines = header_file.readlines()
             if len(lines) < 4:
                 raise OTOKOParsingError("Expected more lines in %s." % header_path)

--- a/sasdata/quantities/_build_tables.py
+++ b/sasdata/quantities/_build_tables.py
@@ -134,7 +134,7 @@ with open("units.py", 'w', encoding=encoding) as fid:
               "# Included from _units_base.py\n"
               "#\n\n")
 
-    with open("_units_base.py", 'r') as base:
+    with open("_units_base.py") as base:
         for line in base:
             # unicode_superscript is a local module when called from
             # _unit_tables.py but a submodule of sasdata.quantities
@@ -406,7 +406,7 @@ with open("accessors.py", 'w', encoding=encoding) as fid:
 
     fid.write('"""'+(warning_text%"_build_tables.py, _accessor_base.py")+'"""\n\n')
 
-    with open("_accessor_base.py", 'r') as base:
+    with open("_accessor_base.py") as base:
         for line in base:
             fid.write(line)
 

--- a/sasdata/quantities/_units_base.py
+++ b/sasdata/quantities/_units_base.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Sequence, Self
+from typing import Self
+from collections.abc import Sequence
 from fractions import Fraction
 
 import numpy as np

--- a/sasdata/quantities/unit_parser.py
+++ b/sasdata/quantities/unit_parser.py
@@ -42,7 +42,7 @@ def parse_single_unit(unit_str: str, unit_group: UnitGroup | None = None, longes
             break
         string_pos += 1
         current_unit = potential_unit_str
-        if not longest_unit and current_unit in lookup_dict.keys():
+        if not longest_unit and current_unit in lookup_dict:
             break
     if current_unit == '':
         return None, unit_str

--- a/sasdata/quantities/units.py
+++ b/sasdata/quantities/units.py
@@ -83,7 +83,8 @@ HHHHHHHHH     HHHHHHHHH  aaaaaaaaaa  aaaa nnnnnn    nnnnnn   ddddddddd   ddddd
 #
 
 from dataclasses import dataclass
-from typing import Sequence, Self
+from typing import Self
+from collections.abc import Sequence
 from fractions import Fraction
 
 import numpy as np

--- a/sasdata/slicing/meshes/mesh.py
+++ b/sasdata/slicing/meshes/mesh.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 

--- a/sasdata/slicing/meshes/meshmerge.py
+++ b/sasdata/slicing/meshes/meshmerge.py
@@ -83,8 +83,8 @@ def meshmerge(mesh_a: Mesh, mesh_b: Mesh) -> tuple[Mesh, np.ndarray, np.ndarray]
     # Find the points where s and t are in (0, 1)
 
     intersection_inds = np.logical_and(
-        np.logical_and(0 < st[:, 0], st[:, 0] < 1),
-        np.logical_and(0 < st[:, 1], st[:, 1] < 1))
+        np.logical_and(st[:, 0] > 0, st[:, 0] < 1),
+        np.logical_and(st[:, 1] > 0, st[:, 1] < 1))
 
     start_points_for_intersections = p1[non_singular][intersection_inds, :]
     deltas_for_intersections = delta1[non_singular][intersection_inds, :]

--- a/sasdata/slicing/meshes/meshmerge.py
+++ b/sasdata/slicing/meshes/meshmerge.py
@@ -83,8 +83,8 @@ def meshmerge(mesh_a: Mesh, mesh_b: Mesh) -> tuple[Mesh, np.ndarray, np.ndarray]
     # Find the points where s and t are in (0, 1)
 
     intersection_inds = np.logical_and(
-        np.logical_and(st[:, 0] > 0, st[:, 0] < 1),
-        np.logical_and(st[:, 1] > 0, st[:, 1] < 1))
+        np.logical_and(0 < st[:, 0], st[:, 0] < 1), # noqa SIM300
+        np.logical_and(0 < st[:, 1], st[:, 1] < 1)) # noqa SIM300
 
     start_points_for_intersections = p1[non_singular][intersection_inds, :]
     deltas_for_intersections = delta1[non_singular][intersection_inds, :]

--- a/sasdata/slicing/meshes/util.py
+++ b/sasdata/slicing/meshes/util.py
@@ -1,4 +1,5 @@
-from typing import Sequence, TypeVar
+from typing import TypeVar
+from collections.abc import Sequence
 
 T = TypeVar("T")
 

--- a/sasdata/slicing/rebinning.py
+++ b/sasdata/slicing/rebinning.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Optional
 from dataclasses import dataclass
 
 import numpy as np
@@ -24,10 +23,10 @@ class Rebinner(ABC):
     def __init__(self):
         """ Base class for rebinning methods"""
 
-        self._bin_mesh_cache: Optional[Mesh] = None # cached version of the output bin mesh
+        self._bin_mesh_cache: Mesh | None = None # cached version of the output bin mesh
 
         # Output dependent caching
-        self._input_cache: Optional[CacheData] = None
+        self._input_cache: CacheData | None = None
 
 
     @abstractmethod

--- a/sasdata/temp_hdf5_reader.py
+++ b/sasdata/temp_hdf5_reader.py
@@ -4,7 +4,7 @@ import h5py
 import logging
 
 import numpy as np
-from typing import Callable, Tuple
+from collections.abc import Callable
 
 
 from h5py._hl.dataset import Dataset as HDF5Dataset
@@ -236,7 +236,7 @@ def parse_sample(node : HDF5Group) -> Sample:
                   orientation=orientation,
                   details=details)
 
-def parse_term(node : HDF5Group) -> Tuple[str, str | Quantity[float]] | None:
+def parse_term(node : HDF5Group) -> tuple[str, str | Quantity[float]] | None:
     name = attr_parse(node, "name")
     unit = attr_parse(node, "unit")
     value = attr_parse(node, "value")

--- a/sasdata/temp_xml_reader.py
+++ b/sasdata/temp_xml_reader.py
@@ -1,7 +1,7 @@
 import logging
 from lxml import etree
 import numpy as np
-from typing import Callable
+from collections.abc import Callable
 
 from sasdata.data import SasData
 from sasdata.dataset_types import one_dim

--- a/sasdata/util.py
+++ b/sasdata/util.py
@@ -1,4 +1,5 @@
-from typing import TypeVar, Callable
+from typing import TypeVar
+from collections.abc import Callable
 
 T = TypeVar("T")
 

--- a/test/sasdataloader/utest_cansas.py
+++ b/test/sasdataloader/utest_cansas.py
@@ -58,7 +58,7 @@ class cansas_reader_xml(unittest.TestCase):
         if dictionary.get(name) is not None:
             i += 1
             name = name.split("_")[0]
-            name += "_{0}".format(i)
+            name += f"_{i}"
             name = self.get_number_of_entries(dictionary, name, i)
         return name
 

--- a/test/transforms/utest_interpolation.py
+++ b/test/transforms/utest_interpolation.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from matplotlib import pyplot as plt
 from numpy.typing import ArrayLike
-from typing import Callable
+from collections.abc import Callable
 
 from sasdata.quantities.plotting import quantity_plot
 from sasdata.quantities.quantity import NamedQuantity, Quantity


### PR DESCRIPTION
This PR addresses all but 11 of the 298 errors for these rules. Note that, as with SasView, I have ignored rules UP008 and UP031.