### PR TITLE
Reify and collect metadata tags

### DIFF
--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -555,9 +555,11 @@ def access_meta(obj: dataclass, key: str) -> Any | None:
             case index if (type(result) is list) and (matches := re.match("\[(\d+?)\](.+)", index)):
                 result = result[int(matches[1])]
                 key = matches[2]
-            case index if (type(result) is dict) and (matches := re.match('\["(.+?)"\](.+)', index)):
+            case name if (type(result) is dict) and (matches := re.match(r'\["(.+)"\](.*)', name)):
                 result = result[matches[1]]
                 key = matches[2]
+            case _:
+                return None
     return result
 
 def meta_tags(obj: dataclass) -> list[str]:

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -12,7 +12,7 @@ Any useful metadata which cannot be included in these classes represent a bug in
 import base64
 import json
 import re
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, fields, is_dataclass
 from typing import Any
 
 import numpy as np
@@ -555,4 +555,20 @@ def access_meta(obj: dataclass, key: str) -> Any | None:
             case index if matches := re.match("\[(\d+?)\](.+)", index):
                 result = result[int(matches[1])]
                 key = matches[2]
+    return result
+
+def meta_tags(obj: dataclass) -> list[str]:
+    result = []
+    items = [("", obj)]
+    while items:
+        path, item = items.pop()
+        match item:
+            case list(xs):
+                for idx, x in enumerate(xs):
+                    items.append((f"{path}[{idx}]", x))
+            case n if is_dataclass(n):
+                for field in fields(item):
+                    items.append((f"{path}.{field.name}", getattr(item, field.name)))
+            case _:
+                result.append(path)
     return result

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -542,18 +542,17 @@ class MetadataEncoder(json.JSONEncoder):
 
 
 def access_meta(obj: dataclass, key: str) -> Any | None:
-    match key:
-        case "":
-            return obj
-        case accessor if accessor.startswith("."):
-            for field in fields(obj):
-                field_string = f".{field.name}"
-                if accessor.startswith(field_string):
-                    rest = accessor[len(field_string):]
-                    return access_meta(getattr(obj, field.name), rest)
-            return None
-        case index if matches := re.match("\[(\d+?)\](.+)", index):
-            idx = int(matches[1])
-            rest = matches[2]
-            return access_meta(obj[idx], rest)
-    return None
+    result = obj
+    while key != "":
+        match key:
+            case accessor if accessor.startswith("."):
+                for field in fields(result):
+                    field_string = f".{field.name}"
+                    if accessor.startswith(field_string):
+                        key = accessor[len(field_string):]
+                        result = getattr(result, field.name)
+                        break
+            case index if matches := re.match("\[(\d+?)\](.+)", index):
+                result = result[int(matches[1])]
+                key = matches[2]
+    return result

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -542,6 +542,8 @@ class MetadataEncoder(json.JSONEncoder):
 
 
 def access_meta(obj: dataclass, key: str) -> Any | None:
+    """Use a string accessor to locate a key from within the data
+    object."""
     result = obj
     while key != "":
         match key:
@@ -549,10 +551,10 @@ def access_meta(obj: dataclass, key: str) -> Any | None:
                 for field in fields(result):
                     field_string = f".{field.name}"
                     if accessor.startswith(field_string):
-                        key = accessor[len(field_string):]
+                        key = accessor[len(field_string) :]
                         result = getattr(result, field.name)
                         break
-            case index if (type(result) is list) and (matches := re.match("\[(\d+?)\](.+)", index)):
+            case index if (type(result) is list) and (matches := re.match(r"\[(\d+?)\](.*)", index)):
                 result = result[int(matches[1])]
                 key = matches[2]
             case name if (type(result) is dict) and (matches := re.match(r'\["(.+)"\](.*)', name)):
@@ -562,7 +564,14 @@ def access_meta(obj: dataclass, key: str) -> Any | None:
                 return None
     return result
 
+
 def meta_tags(obj: dataclass) -> list[str]:
+    """Find all leaf accessors form a data object.
+
+    The tags returns by this function are the key values with which
+    access_meta might be called on this object.
+
+    """
     result = []
     items = [("", obj)]
     while items:

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -552,8 +552,11 @@ def access_meta(obj: dataclass, key: str) -> Any | None:
                         key = accessor[len(field_string):]
                         result = getattr(result, field.name)
                         break
-            case index if matches := re.match("\[(\d+?)\](.+)", index):
+            case index if (type(result) is list) and (matches := re.match("\[(\d+?)\](.+)", index)):
                 result = result[int(matches[1])]
+                key = matches[2]
+            case index if (type(result) is dict) and (matches := re.match('\["(.+?)"\](.+)', index)):
+                result = result[matches[1]]
                 key = matches[2]
     return result
 
@@ -566,6 +569,9 @@ def meta_tags(obj: dataclass) -> list[str]:
             case list(xs):
                 for idx, x in enumerate(xs):
                     items.append((f"{path}[{idx}]", x))
+            case dict(xs):
+                for k, v in xs.items():
+                    items.append((f'{path}["{k}"]', v))
             case n if is_dataclass(n):
                 for field in fields(item):
                     items.append((f"{path}.{field.name}", getattr(item, field.name)))

--- a/sasdata/metadata.py
+++ b/sasdata/metadata.py
@@ -576,11 +576,11 @@ def access_meta(obj: dataclass, key: str) -> Any | None:
     while key != "":
         match key:
             case accessor if accessor.startswith("."):
-                for field in fields(result):
-                    field_string = f".{field.name}"
+                for fld in fields(result):
+                    field_string = f".{fld.name}"
                     if accessor.startswith(field_string):
                         key = accessor[len(field_string) :]
-                        result = getattr(result, field.name)
+                        result = getattr(result, fld.name)
                         break
             case index if (type(result) is list) and (matches := re.match(r"\[(\d+?)\](.*)", index)):
                 result = result[int(matches[1])]
@@ -638,8 +638,8 @@ def meta_tags(obj: dataclass) -> list[str]:
                 for k, v in xs.items():
                     items.append((f'{path}["{k}"]', v))
             case n if is_dataclass(n):
-                for field in fields(item):
-                    items.append((f"{path}.{field.name}", getattr(item, field.name)))
+                for fld in fields(item):
+                    items.append((f"{path}.{fld.name}", getattr(item, fld.name)))
             case _:
                 result.append(path)
     return result
@@ -663,9 +663,9 @@ def collect_tags(objs: list[dataclass]) -> TagCollection:
     collection.
 
     To be more specific, if `obj.name` exists and has the same value
-    for every `obj` in `objs`, the the string ".name" will be included
-    in the `singular` set.  If there are at least two distinct values
-    for `obj.name`, then ".name" will be in the `variable` set.
+    for every `obj` in `objs`, the string ".name" will be included in
+    the `singular` set.  If there are at least two distinct values for
+    `obj.name`, then ".name" will be in the `variable` set.
 
     """
     if not objs:

--- a/test/sasdataloader/utest_metadata_tags.py
+++ b/test/sasdataloader/utest_metadata_tags.py
@@ -7,7 +7,7 @@ import pytest
 from sasdata.metadata import Metadata, Process, access_meta, meta_tags, collect_tags
 
 
-@pytest.mark.sasdata3
+@pytest.mark.sasdata
 def test_tag_access():
     """Check ability to access terms by name"""
     processes = [Process(name="Frobulator", date=None, description=None, terms={"Bobbin": "Threadbare"}, notes=[])]
@@ -28,7 +28,7 @@ def test_tag_access():
     assert access_meta(meta, '.process[0].terms["Bobbin"]') == "Threadbare"
 
 
-@pytest.mark.sasdata3
+@pytest.mark.sasdata
 def test_tag_listing():
     """Check the ability to collect term names from object"""
     processes = [Process(name="Frobulator", date=None, description=None, terms={"Bobbin": "Threadbare"}, notes=[])]
@@ -57,7 +57,7 @@ def test_tag_listing():
     ]
 
 
-@pytest.mark.sasdata3
+@pytest.mark.sasdata
 def test_tag_merge():
     """Check ability to access terms by name"""
     processes = [

--- a/test/sasdataloader/utest_metadata_tags.py
+++ b/test/sasdataloader/utest_metadata_tags.py
@@ -9,7 +9,7 @@ from sasdata.metadata import Metadata, Process, access_meta, meta_tags
 
 @pytest.mark.sasdata3
 def test_tag_access():
-    processes = [Process(name="Frobulator", date=None, description=None, terms={}, notes=[])]
+    processes = [Process(name="Frobulator", date=None, description=None, terms={"Bobbin": "Threadbare"}, notes=[])]
     meta = Metadata(
         title="Example",
         run=[5, 11],
@@ -24,7 +24,7 @@ def test_tag_access():
     assert access_meta(meta, ".run") == [5, 11]
     assert access_meta(meta, ".process")[0].name == "Frobulator"
     assert access_meta(meta, ".process[0].name") == "Frobulator"
-    assert access_meta(meta, ".process[0].name") == "Frobulator"
+    assert access_meta(meta, '.process[0].terms["Bobbin"]') == "Threadbare"
 
 
 @pytest.mark.sasdata3

--- a/test/sasdataloader/utest_metadata_tags.py
+++ b/test/sasdataloader/utest_metadata_tags.py
@@ -4,7 +4,7 @@ Unit tests for metadata tag access
 
 import pytest
 
-from sasdata.metadata import Metadata, Process, access_meta, meta_tags
+from sasdata.metadata import Metadata, Process, access_meta, meta_tags, collect_tags
 
 
 @pytest.mark.sasdata3
@@ -55,3 +55,54 @@ def test_tag_listing():
         ".sample",
         ".title",
     ]
+
+
+@pytest.mark.sasdata3
+def test_tag_merge():
+    """Check ability to access terms by name"""
+    processes = [
+        Process(
+            name="Frobulator",
+            date=None,
+            description=None,
+            terms={"Bobbin": "Threadbare", "Guybrush": "Threepwood"},
+            notes=[],
+        )
+    ]
+    meta = Metadata(
+        title="Example",
+        run=[5, 11],
+        definition="An example metadata set",
+        process=processes,
+        sample=None,
+        instrument=None,
+        raw=None,
+    )
+
+    processes2 = [
+        Process(
+            name="Frobulator",
+            date=None,
+            description=None,
+            terms={"Bobbin": "Threadbare", "Doctor Ed": "Edison"},
+            notes=[],
+        )
+    ]
+    meta2 = Metadata(
+        title="Example 2",
+        run=[5, 11, 12],
+        definition="A second example metadata set",
+        process=processes2,
+        sample=None,
+        instrument=None,
+        raw=None,
+    )
+
+    result = collect_tags([meta, meta2])
+
+    assert result.singular == set([".process[0].name", '.process[0].date', '.process[0].description', '.process[0].terms["Bobbin"]', ".run[0]", ".run[1]",  ".sample", ".instrument", ".raw"])
+
+    # Only meta2 has a run[2] term, so it cannot be collected
+    assert ".run[2]" not in result.singular
+
+    assert result.variable == set([".definition", ".title"])

--- a/test/sasdataloader/utest_metadata_tags.py
+++ b/test/sasdataloader/utest_metadata_tags.py
@@ -24,10 +24,32 @@ def test_tag_access():
     assert access_meta(meta, ".run") == [5, 11]
     assert access_meta(meta, ".process")[0].name == "Frobulator"
     assert access_meta(meta, ".process[0].name") == "Frobulator"
+    assert access_meta(meta, ".process[0].name") == "Frobulator"
+
 
 @pytest.mark.sasdata3
 def test_tag_listing():
-    processes = [Process(name="Frobulator", date=None, description=None, terms={}, notes=[])]
-    meta = Metadata(title="Example", run=[5, 11], definition="An example metadata set", process=processes, sample=None, instrument=None, raw=None)
+    processes = [Process(name="Frobulator", date=None, description=None, terms={"Bobbin": "Threadbare"}, notes=[])]
+    meta = Metadata(
+        title="Example",
+        run=[5, 11],
+        definition="An example metadata set",
+        process=processes,
+        sample=None,
+        instrument=None,
+        raw=None,
+    )
 
-    assert sorted(meta_tags(meta)) == sorted([".raw", ".sample", ".instrument", ".definition", ".title", ".run[0]", ".run[1]", ".process[0].terms", ".process[0].date", ".process[0].name", ".process[0].description"])
+    assert sorted(meta_tags(meta)) == [
+        ".definition",
+        ".instrument",
+        ".process[0].date",
+        ".process[0].description",
+        ".process[0].name",
+        '.process[0].terms["Bobbin"]',
+        ".raw",
+        ".run[0]",
+        ".run[1]",
+        ".sample",
+        ".title",
+    ]

--- a/test/sasdataloader/utest_metadata_tags.py
+++ b/test/sasdataloader/utest_metadata_tags.py
@@ -4,7 +4,7 @@ Unit tests for metadata tag access
 
 import pytest
 
-from sasdata.metadata import Metadata, Process, access_meta, meta_tags, collect_tags
+from sasdata.metadata import Metadata, Process, access_meta, collect_tags, meta_tags
 
 
 @pytest.mark.sasdata
@@ -100,7 +100,19 @@ def test_tag_merge():
 
     result = collect_tags([meta, meta2])
 
-    assert result.singular == set([".process[0].name", '.process[0].date', '.process[0].description', '.process[0].terms["Bobbin"]', ".run[0]", ".run[1]",  ".sample", ".instrument", ".raw"])
+    assert result.singular == set(
+        [
+            ".process[0].name",
+            ".process[0].date",
+            ".process[0].description",
+            '.process[0].terms["Bobbin"]',
+            ".run[0]",
+            ".run[1]",
+            ".sample",
+            ".instrument",
+            ".raw",
+        ]
+    )
 
     # Only meta2 has a run[2] term, so it cannot be collected
     assert ".run[2]" not in result.singular

--- a/test/sasdataloader/utest_metadata_tags.py
+++ b/test/sasdataloader/utest_metadata_tags.py
@@ -4,7 +4,7 @@ Unit tests for metadata tag access
 
 import pytest
 
-from sasdata.metadata import Metadata, Process, access_meta
+from sasdata.metadata import Metadata, Process, access_meta, meta_tags
 
 
 @pytest.mark.sasdata3
@@ -24,3 +24,10 @@ def test_tag_access():
     assert access_meta(meta, ".run") == [5, 11]
     assert access_meta(meta, ".process")[0].name == "Frobulator"
     assert access_meta(meta, ".process[0].name") == "Frobulator"
+
+@pytest.mark.sasdata3
+def test_tag_listing():
+    processes = [Process(name="Frobulator", date=None, description=None, terms={}, notes=[])]
+    meta = Metadata(title="Example", run=[5, 11], definition="An example metadata set", process=processes, sample=None, instrument=None, raw=None)
+
+    assert sorted(meta_tags(meta)) == sorted([".raw", ".sample", ".instrument", ".definition", ".title", ".run[0]", ".run[1]", ".process[0].terms", ".process[0].date", ".process[0].name", ".process[0].description"])

--- a/test/sasdataloader/utest_metadata_tags.py
+++ b/test/sasdataloader/utest_metadata_tags.py
@@ -9,6 +9,7 @@ from sasdata.metadata import Metadata, Process, access_meta, meta_tags
 
 @pytest.mark.sasdata3
 def test_tag_access():
+    """Check ability to access terms by name"""
     processes = [Process(name="Frobulator", date=None, description=None, terms={"Bobbin": "Threadbare"}, notes=[])]
     meta = Metadata(
         title="Example",
@@ -29,6 +30,7 @@ def test_tag_access():
 
 @pytest.mark.sasdata3
 def test_tag_listing():
+    """Check the ability to collect term names from object"""
     processes = [Process(name="Frobulator", date=None, description=None, terms={"Bobbin": "Threadbare"}, notes=[])]
     meta = Metadata(
         title="Example",

--- a/test/sasdataloader/utest_metadata_tags.py
+++ b/test/sasdataloader/utest_metadata_tags.py
@@ -1,0 +1,26 @@
+"""
+Unit tests for metadata tag access
+"""
+
+import pytest
+
+from sasdata.metadata import Metadata, Process, access_meta
+
+
+@pytest.mark.sasdata3
+def test_tag_access():
+    processes = [Process(name="Frobulator", date=None, description=None, terms={}, notes=[])]
+    meta = Metadata(
+        title="Example",
+        run=[5, 11],
+        definition="An example metadata set",
+        process=processes,
+        sample=None,
+        instrument=None,
+        raw=None,
+    )
+
+    assert access_meta(meta, ".title") == "Example"
+    assert access_meta(meta, ".run") == [5, 11]
+    assert access_meta(meta, ".process")[0].name == "Frobulator"
+    assert access_meta(meta, ".process[0].name") == "Frobulator"


### PR DESCRIPTION
This PR is based around collecting metadata value from a group of metadata.  The interface is based around three functions:

- `meta_tag` will return a list of valid metadata accessor strings from an object
- `access_meta` will return the metadata value at the accessor
- `collect_tags` will loop through a list of objects and returns a `TagCollection`.  The `TagCollection.singular` is the set of accessors which have the same value in every object while `TagCollection.variable` is the set of accessors where the value changes.  Any tags which are not present in every object is ignored.

This PR also does a ruff reformat of `metadata.py`, so the changes before the `access_meta` function aren't particularly interesting.

Closes #132 