### PR TITLE
PyPi Upload fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
 
     env:
-       BUILD_WHEEL: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12') && 'true' || '' }}
+       BUILD_WHEEL: ${{ matrix.python-version == '3.12' && 'true' || '' }}
 
     steps:
 


### PR DESCRIPTION
The PyPi uploads were looking for the wrong file names. This should fix that issue, and extends the wheel creation beyond ubuntu.