### PR TITLE
Adds local pre-commit hook for ruff linting auto fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
         with:
+          version: "latest"
           args: "check --fix-only --exit-non-zero-on-fix"
       - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,3 @@ tests.log
 /installers/dist
 *.exe
 sasdata/_version.py
-
-# Local pre-commit hooks
-.pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+default_install_hook_types: [pre-commit, pre-push]
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.9
+    hooks:
+      # Run the linter, applying any available fixes
+      - id: ruff-check
+        stages: [ pre-commit, pre-push ]
+        args: [ --fix-only ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ select = ["E",       # pycodestyle errors
           "F",       # pyflakes
           "I",       # isort
           "UP",      # pyupgrade
+          "W",       # pycodestyle warnings
           "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
           "SIM300"]  # Yoda condition detected
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ html5lib
 
 # Other stuff
 matplotlib
+pre-commit


### PR DESCRIPTION
This local hook mirrors the CI functionality of detecting ruff linting errors and can be used locally to check prior to committing and pushing to the remote. This has already been introduced into SasView in SasView/sasview#3573