### PR TITLE
Refactor24 join tests

### DIFF
--- a/test/sasdataloader/utest_sasdataload.py
+++ b/test/sasdataloader/utest_sasdataload.py
@@ -25,8 +25,8 @@ from sasdata.temp_ascii_reader import (
 )
 from sasdata.temp_ascii_reader import load_data as ascii_load_data
 from sasdata.temp_hdf5_reader import load_data as hdf_load_data
-from sasdata.temp_xml_reader import load_data as xml_load_data
 from sasdata.temp_sesans_reader import load_data as sesans_load_data
+from sasdata.temp_xml_reader import load_data as xml_load_data
 
 
 def local_load(path: str):


### PR DESCRIPTION
This removes most of my old testing framework and combines it in with the work that James did.  This also fixes the issues with the H5 test not passing.  The following issues are known, but are a bit beyond the scope of the current PR:

- Eventually, the "reference" files should be removed and everything should use the `expected_values` and `expected_metadata`.  This is likely my next PR
- `round_trip` should be true for *all* tests, but it is currently failing on some tests,  I didn't want to mark those tests as broken, because all of the loading infrastructure should still be tests, but some of these files cannot survive a round trip through h5.

There's also a bit of a future refactor to perform because the test framework was designed around the ASCII reader, where files only contain a single dataset.  The XML and HDF files can contain multiple datasets, so a little infrastructure was added to choose only a single dataset from the file.  However, a better system would be to test the ASCII and SESANS as special cases containing only a single dataset and generally work with multiple data sets per file.