### PR TITLE
Fix for slicers not working for 2D residual plots

### DIFF
--- a/sasdata/data_util/manipulations.py
+++ b/sasdata/data_util/manipulations.py
@@ -357,7 +357,9 @@ class _Slab:
 
         # Get data
         data = data2D.data[np.isfinite(data2D.data)]
-        err_data = data2D.err_data[np.isfinite(data2D.data)]
+        err_data =None
+        if data2D.err_data is not None:
+            err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]
         qy_data = data2D.qy_data[np.isfinite(data2D.data)]
         mask_data = data2D.mask[np.isfinite(data2D.data)]
@@ -558,7 +560,9 @@ class Boxsum:
             raise RuntimeError(msg)
         # Get data
         data = data2D.data[np.isfinite(data2D.data)]
-        err_data = data2D.err_data[np.isfinite(data2D.data)]
+        err_data = None
+        if data2D.err_data is not None:
+            err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]
         qy_data = data2D.qy_data[np.isfinite(data2D.data)]
         mask_data = data2D.mask[np.isfinite(data2D.data)]
@@ -654,7 +658,9 @@ class CircularAverage:
         # Get data W/ finite values
         data = data2D.data[np.isfinite(data2D.data)]
         q_data = data2D.q_data[np.isfinite(data2D.data)]
-        err_data = data2D.err_data[np.isfinite(data2D.data)]
+        err_data = None
+        if data2D.err_data is not None:
+            err_data = data2D.err_data[np.isfinite(data2D.data)]
         mask_data = data2D.mask[np.isfinite(data2D.data)]
 
         dq_data = None
@@ -788,7 +794,9 @@ class Ring:
         # Get data
         data = data2D.data[np.isfinite(data2D.data)]
         q_data = data2D.q_data[np.isfinite(data2D.data)]
-        err_data = data2D.err_data[np.isfinite(data2D.data)]
+        err_data = None
+        if data2D.err_data is not None:
+            err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]
         qy_data = data2D.qy_data[np.isfinite(data2D.data)]
         mask_data = data2D.mask[np.isfinite(data2D.data)]
@@ -893,7 +901,9 @@ class _Sector:
         # Get all the data & info
         data = data2D.data[np.isfinite(data2D.data)]
         q_data = data2D.q_data[np.isfinite(data2D.data)]
-        err_data = data2D.err_data[np.isfinite(data2D.data)]
+        err_data=None
+        if data2D.err_data is not None:
+            err_data = data2D.err_data[np.isfinite(data2D.data)]
         qx_data = data2D.qx_data[np.isfinite(data2D.data)]
         qy_data = data2D.qy_data[np.isfinite(data2D.data)]
         mask_data = data2D.mask[np.isfinite(data2D.data)]
@@ -1010,7 +1020,7 @@ class _Sector:
             # Get the total y
             y[i_bin] += data_n
             x[i_bin] += q_value
-            if err_data[n] is None or err_data[n] == 0.0:
+            if err_data is None or err_data[n] == 0.0:
                 if data_n < 0:
                     data_n = -data_n
                 y_err[i_bin] += data_n


### PR DESCRIPTION
This PR fixes an issue where data.err can be None for certain plots, like residuals causing an error.
This should be checked when data.err is being subscripted. The issue has been fixed before in sasview as https://github.com/SasView/sasdata/issues/170 . This PR will apply the same fix to sasdata. Fixes #170 and fixes https://github.com/SasView/sasdata/issues/35