### PR TITLE
Perf: Optimize string concatenation using .join()

### DIFF
--- a/sasdata/data_util/nxsunit.py
+++ b/sasdata/data_util/nxsunit.py
@@ -317,7 +317,7 @@ def _format_unit_structure(unit: str | None = None) -> list[str]:
     all_prefixes = list(PREFIX.keys())
     all_prefixes.extend(list(SHORT_PREFIX.keys()))
     for prefix in all_prefixes:
-        unit = unit.replace(prefix + "*", prefix)
+        unit = unit.replace("".join([prefix, "*"]), prefix)
     # a^-m*b^-n -> a^-m b^-n
     unit = unit.replace('*', ' ')
     # invUnit or 1/unit -> /unit

--- a/sasdata/dataloader/readers/cansas_reader.py
+++ b/sasdata/dataloader/readers/cansas_reader.py
@@ -194,13 +194,13 @@ class Reader(XMLreader):
             self.current_datainfo.meta_data["loader"] = "CanSAS XML 1D"
             self.current_datainfo.meta_data[
                 PREPROCESS] = self.processing_instructions
-            self.base_ns = "{" + CANSAS_NS.get(self.cansas_version).get("ns") + "}"
+            self.base_ns = "".join(["{", CANSAS_NS.get(self.cansas_version).get("ns"), "}"])
         if self._is_call_local() and not recurse:
             self.current_datainfo.filename = self.filepath.name
         # Create an empty dataset if no data has been passed to the reader
         if self.current_dataset is None:
             self._initialize_new_data_set(dom)
-        self.base_ns = "{" + CANSAS_NS.get(self.cansas_version).get("ns") + "}"
+        self.base_ns = "".join(["{", CANSAS_NS.get(self.cansas_version).get("ns"), "}"])
 
         # Loop through each child in the parent element
         for node in dom:


### PR DESCRIPTION
This pull request addresses a small performance issue I noticed in `nxsunit.py` and `cansas_reader.py`.

I updated the code to use `.join()` instead of `+` for string concatenation. This ensures linear time complexity, which helps performance across different Python interpreters, and also aligns with PEP 8 recommendations.

https://peps.python.org/pep-0008/#programming-recommendations