### PR TITLE
Remove non-runtime dependencies from requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ To run sasdata from the source, create a python environment using python 3.10 or
        $ conda activate sasdata
        (sasdata) $ python -m pip install -e .
 
+If you are wanting to work on the development of `sasdata`, then the packages to run
+unit tests and build documentation can be installed with::
+
+      $ python -m pip install -r requirements-dev.txt
+
 ## Data Formats
 
 The `Loader()` class is directly callable so a transient call can be made to the class or, for cases where repeated calls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ files = [ "requirements.txt" ]
 
 [tool.hatch.metadata.hooks.requirements_txt.optional-dependencies]
 test = [ "requirements-test.txt" ]
+dev = [ "requirements-dev.txt" ]
 
 
 [tool.hatch.version]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+-r requirements-test.txt
+
+# Documentation (future)
+sphinx
+html5lib
+
+# Other stuff
+pre-commit

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,4 @@
+# Unit testing
 pytest
+unittest-xml-reporting
+matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,3 @@ lxml
 # Calculation
 numpy
 scipy
-
-# Unit testing
-pytest
-unittest-xml-reporting
-
-# Documentation (future)
-sphinx
-html5lib
-
-# Other stuff
-matplotlib
-pre-commit


### PR DESCRIPTION
Move development-time dependencies into `requirements-dev.txt`, to ensure that the `sasdata` wheel does not end up depending on testing tools.

Closes: #211 